### PR TITLE
[Chore] Add local H2 test profile & DB config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ out/
 .vscode/
 .env
 src/main/resources/application.yaml
-src/test/resources/application-test.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 .env
 src/main/resources/application.yaml
+src/test/resources/application-test.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	//H2 dependency added for testing purposes
+	testImplementation 'com.h2database:h2:2.2.224'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/gdg/coffee/CoffeeApplicationTests.java
+++ b/src/test/java/com/gdg/coffee/CoffeeApplicationTests.java
@@ -2,12 +2,12 @@ package com.gdg.coffee;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CoffeeApplicationTests {
-
 	@Test
 	void contextLoads() {
 	}
-
 }

--- a/src/test/java/com/gdg/coffee/cafe/repository/CafeRepositoryTest.java
+++ b/src/test/java/com/gdg/coffee/cafe/repository/CafeRepositoryTest.java
@@ -13,7 +13,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+//for test
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+import org.springframework.test.context.ActiveProfiles;
+
+
 @DataJpaTest
+@ActiveProfiles("test")  // application‑test.yaml 적용
+@AutoConfigureTestDatabase(replace = NONE)  // H2 설정 유지, Spring이 임의 교체 못 하게
 class CafeRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## 🍃 관련이슈
CI 환경에서도 빠르고 독립적인 테스트 실행이 가능하게 구성
단위 테스트가 실제 MySQL 대신 H2 인메모리 DB로 수행되는 것이 목표

## 🌱 변경사항

✅ 설정 | src/test/resources/application-test.yaml
-  H2 데이터소스·Hibernate DDL 옵션 등 테스트 전용 설정 추가

♻️ Gradle |  build.gradle
- H2 의존성(+), 테스트 태스크 전용 Active profile 지정

## 🌷 참고사항

### 테스트
- ./gradlew clean test 명령으로 모든 단위 테스트 통과 확인

- 로컬 IDE(JUnit)에서도 H2 로 자동 스위칭되는지 검증

### 참고/주의
- 운영 프로파일(prod/dev)은 영향을 받지 않습니다.

- 현재 테스트용 DDL 전략은 create-drop이며, 통합 테스트에서는 update로의 수정이 필요할 수 있습니다.