### PR TITLE
[Feat] Bean 초기 구조 구성

### DIFF
--- a/src/main/java/com/gdg/coffee/bean/controller/BeanController.java
+++ b/src/main/java/com/gdg/coffee/bean/controller/BeanController.java
@@ -1,0 +1,51 @@
+package com.gdg.coffee.bean.controller;
+
+import com.gdg.coffee.bean.dto.BeanRequestDto;
+import com.gdg.coffee.bean.dto.BeanResponseDto;
+import com.gdg.coffee.bean.service.BeanService;
+import com.gdg.coffee.global.common.response.ApiResponse;
+import com.gdg.coffee.global.common.response.bean.BeanSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/beans")
+@RequiredArgsConstructor
+@Validated
+public class BeanController {
+
+    private final BeanService beanService;
+
+    /** 1. 원두 등록 (201 CREATED) */
+    @PostMapping
+    public ApiResponse<BeanResponseDto> createBean(@RequestBody BeanRequestDto requestDto) {
+        BeanResponseDto created = beanService.createBean(requestDto);
+        return ApiResponse.success(BeanSuccessCode.BEAN_CREATE_SUCCESS, created);
+    }
+
+    /** 2. 카페별 원두 목록 조회 (200 OK) */
+    @GetMapping("/cafe/{cafeId}")
+    public ApiResponse<List<BeanResponseDto>> getBeansByCafe(@PathVariable Long cafeId) {
+        List<BeanResponseDto> list = beanService.getBeansByCafeId(cafeId);
+        return ApiResponse.success(BeanSuccessCode.BEAN_LIST_SUCCESS, list);
+    }
+
+    /** 3. 원두 정보 수정 (200 OK) */
+    @PutMapping("/{beanId}")
+    public ApiResponse<BeanResponseDto> updateBean(
+            @PathVariable Long beanId,
+            @RequestBody BeanRequestDto requestDto) {
+        BeanResponseDto updated = beanService.updateBean(beanId, requestDto);
+        return ApiResponse.success(BeanSuccessCode.BEAN_UPDATE_SUCCESS, updated);
+    }
+
+    /** 4. 원두 삭제 (200 OK) */
+    @DeleteMapping("/{beanId}")
+    public ApiResponse<Void> deleteBean(@PathVariable Long beanId) {
+        beanService.deleteBean(beanId);
+        return ApiResponse.success(BeanSuccessCode.BEAN_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/gdg/coffee/bean/domain/Bean.java
+++ b/src/main/java/com/gdg/coffee/bean/domain/Bean.java
@@ -1,0 +1,48 @@
+package com.gdg.coffee.bean.domain;
+
+import com.gdg.coffee.bean.dto.BeanRequestDto;
+import com.gdg.coffee.domain.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 원두(Bean) 엔티티 클래스
+ */
+@Entity
+@Table(name = "bean")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Bean extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bean_id")
+    private Long beanId;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String origin;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    // Cafe FK
+    @Column(name = "cafe_id", nullable = false)
+    private Long cafeId;
+
+    /**
+     * 엔티티 업데이트 메서드
+     * 전달된 DTO의 값이 null이 아닐 경우에만 필드를 덮어쓴다.
+     */
+    public void update(BeanRequestDto dto) {
+        if (dto.getName() != null) this.name = dto.getName();
+        if (dto.getOrigin() != null) this.origin = dto.getOrigin();
+        if (dto.getDescription() != null) this.description = dto.getDescription();
+        if (dto.getCafeId() != null) this.cafeId = dto.getCafeId();
+    }
+}

--- a/src/main/java/com/gdg/coffee/bean/dto/BeanRequestDto.java
+++ b/src/main/java/com/gdg/coffee/bean/dto/BeanRequestDto.java
@@ -1,0 +1,38 @@
+package com.gdg.coffee.bean.dto;
+
+import com.gdg.coffee.bean.domain.Bean;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 원두(Bean) 생성 및 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class BeanRequestDto {
+
+    @NotBlank(message = "원두 이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "원산지는 필수입니다.")
+    private String origin;
+
+    private String description;
+
+    @NotNull(message = "카페 ID는 필수입니다.")
+    private Long cafeId;
+
+    /**
+     * DTO -> Entity 변환
+     */
+    public Bean toEntity() {
+        return Bean.builder()
+                .name(name)
+                .origin(origin)
+                .description(description)
+                .cafeId(cafeId)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/coffee/bean/dto/BeanResponseDto.java
+++ b/src/main/java/com/gdg/coffee/bean/dto/BeanResponseDto.java
@@ -1,0 +1,34 @@
+package com.gdg.coffee.bean.dto;
+
+import com.gdg.coffee.bean.domain.Bean;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 원두(Bean) 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BeanResponseDto {
+
+    private Long beanId;
+    private String name;
+    private String origin;
+    private String description;
+    private Long cafeId;
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static BeanResponseDto fromEntity(Bean bean) {
+        return new BeanResponseDto(
+                bean.getBeanId(),
+                bean.getName(),
+                bean.getOrigin(),
+                bean.getDescription(),
+                bean.getCafeId()
+        );
+    }
+}

--- a/src/main/java/com/gdg/coffee/bean/repository/BeanRepository.java
+++ b/src/main/java/com/gdg/coffee/bean/repository/BeanRepository.java
@@ -1,0 +1,10 @@
+package com.gdg.coffee.bean.repository;
+
+import com.gdg.coffee.bean.domain.Bean;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BeanRepository extends JpaRepository<Bean, Long> {
+    List<Bean> findAllByCafeId(Long cafeId);
+}

--- a/src/main/java/com/gdg/coffee/bean/service/BeanService.java
+++ b/src/main/java/com/gdg/coffee/bean/service/BeanService.java
@@ -1,0 +1,20 @@
+package com.gdg.coffee.bean.service;
+
+import com.gdg.coffee.bean.dto.BeanRequestDto;
+import com.gdg.coffee.bean.dto.BeanResponseDto;
+
+import java.util.List;
+
+public interface BeanService {
+    /** 원두 등록 */
+    BeanResponseDto createBean(BeanRequestDto requestDto);
+
+    /** 카페별 원두 목록 조회 */
+    List<BeanResponseDto> getBeansByCafeId(Long cafeId);
+
+    /** 원두 정보 수정 */
+    BeanResponseDto updateBean(Long beanId, BeanRequestDto requestDto);
+
+    /** 원두 삭제 */
+    void deleteBean(Long beanId);
+}

--- a/src/main/java/com/gdg/coffee/bean/service/Impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/bean/service/Impl/BeanServiceImpl.java
@@ -1,4 +1,0 @@
-package com.gdg.coffee.bean.service.Impl;
-
-public class BeanServiceImpl {
-}

--- a/src/main/java/com/gdg/coffee/bean/service/Impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/bean/service/Impl/BeanServiceImpl.java
@@ -1,0 +1,4 @@
+package com.gdg.coffee.bean.service.Impl;
+
+public class BeanServiceImpl {
+}

--- a/src/main/java/com/gdg/coffee/bean/service/impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/bean/service/impl/BeanServiceImpl.java
@@ -1,0 +1,48 @@
+package com.gdg.coffee.bean.service.impl;
+
+import com.gdg.coffee.bean.dto.BeanRequestDto;
+import com.gdg.coffee.bean.dto.BeanResponseDto;
+import com.gdg.coffee.bean.repository.BeanRepository;
+import com.gdg.coffee.bean.service.BeanService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BeanServiceImpl implements BeanService {
+
+    private final BeanRepository beanRepository;
+
+    /** 1. 원두 등록 */
+    @Override
+    public BeanResponseDto createBean(BeanRequestDto requestDto) {
+        // just stub
+        throw new UnsupportedOperationException("createBean not implemented yet");
+    }
+
+    /** 2. 카페별 원두 목록 조회 */
+    @Override
+    @Transactional(readOnly = true)
+    public List<BeanResponseDto> getBeansByCafeId(Long cafeId) {
+        // just stub
+        throw new UnsupportedOperationException("getBeansByCafeId not implemented yet");
+    }
+
+    /** 3. 원두 정보 수정 */
+    @Override
+    public BeanResponseDto updateBean(Long beanId, BeanRequestDto requestDto) {
+        // just stub
+        throw new UnsupportedOperationException("updateBean not implemented yet");
+    }
+
+    /** 4. 원두 삭제 */
+    @Override
+    public void deleteBean(Long beanId) {
+        // just stub
+        throw new UnsupportedOperationException("deleteBean not implemented yet");
+    }
+}

--- a/src/main/java/com/gdg/coffee/cafe/domain/Cafe.java
+++ b/src/main/java/com/gdg/coffee/cafe/domain/Cafe.java
@@ -50,6 +50,10 @@ public class Cafe extends BaseTime {
     @Column(name = "collect_schedule", nullable = false, length = 100)
     private String collectSchedule;
 
+    /**
+     * 엔티티 업데이트 메서드
+     * 전달된 DTO의 값이 null이 아닐 경우에만 필드를 덮어쓴다.
+     */
     public void update(CafeRequestDto dto) {
         if (dto.getName() != null)            this.name            = dto.getName();
         if (dto.getAddress() != null)         this.address         = dto.getAddress();

--- a/src/main/java/com/gdg/coffee/global/common/response/bean/BeanErrorCode.java
+++ b/src/main/java/com/gdg/coffee/global/common/response/bean/BeanErrorCode.java
@@ -1,0 +1,34 @@
+package com.gdg.coffee.global.common.response.bean;
+
+import com.gdg.coffee.global.common.type.ErrorResponse;
+import org.springframework.http.HttpStatus;
+
+public enum BeanErrorCode implements ErrorResponse {
+    BEAN_NOT_FOUND    (HttpStatus.NOT_FOUND,    "BEAN_NOT_FOUND",    "존재하지 않는 원두입니다."),
+    BEAN_FORBIDDEN    (HttpStatus.FORBIDDEN,    "BEAN_FORBIDDEN",    "원두 작업 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String     code;
+    private final String     message;
+
+    BeanErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code       = code;
+        this.message    = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/gdg/coffee/global/common/response/bean/BeanSuccessCode.java
+++ b/src/main/java/com/gdg/coffee/global/common/response/bean/BeanSuccessCode.java
@@ -1,0 +1,36 @@
+package com.gdg.coffee.global.common.response.bean;
+
+import com.gdg.coffee.global.common.type.SuccessResponse;
+import org.springframework.http.HttpStatus;
+
+public enum BeanSuccessCode implements SuccessResponse {
+    BEAN_CREATE_SUCCESS (HttpStatus.CREATED, "BEAN_CREATE_SUCCESS", "원두가 성공적으로 생성되었습니다."),
+    BEAN_LIST_SUCCESS   (HttpStatus.OK,      "BEAN_LIST_SUCCESS",   "원두 목록을 성공적으로 조회했습니다."),
+    BEAN_UPDATE_SUCCESS (HttpStatus.OK,      "BEAN_UPDATE_SUCCESS", "원두 정보가 성공적으로 수정되었습니다."),
+    BEAN_DELETE_SUCCESS (HttpStatus.OK,      "BEAN_DELETE_SUCCESS", "원두가 성공적으로 삭제되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String     code;
+    private final String     message;
+
+    BeanSuccessCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code       = code;
+        this.message    = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## 🍃 관련이슈
- Resolved: #18 

## 🌱 변경사항
- Bean 초기 구조 구성
  - `Bean` 엔티티 추가  
  - `BeanRequestDto` / `BeanResponseDto` 정의  
  - `BeanRepository` + `findAllByCafeId` 메서드 선언  
  - `BeanService` 인터페이스 선언  
  - `BeanServiceImpl` CRUD 메서드 스텁 구현  
  - `BeanController` CRUD 엔드포인트 스캐폴딩  

- 글로벌 응답 코드 추가
  - `global/common/response/bean/BeanErrorCode` enum 정의  
  - `global/common/response/bean/BeanSuccessCode` enum 정의 
