### PR TITLE
Feature#25/token auth cafe bean

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
@@ -50,7 +50,8 @@ public class BeanController {
     /** 4. 원두 삭제 (200 OK) */
     @DeleteMapping("/{beanId}")
     public ApiResponse<Void> deleteBean(@PathVariable Long beanId) {
-        beanService.deleteBean(beanId);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        beanService.deleteBean(beanId, memberId);
         return ApiResponse.success(BeanSuccessCode.BEAN_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
@@ -5,6 +5,7 @@ import com.gdg.coffee.domain.bean.dto.BeanResponseDto;
 import com.gdg.coffee.domain.bean.exception.BeanSuccessCode;
 import com.gdg.coffee.domain.bean.service.BeanService;
 import com.gdg.coffee.global.common.response.ApiResponse;
+import com.gdg.coffee.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -23,7 +24,8 @@ public class BeanController {
     /** 1. 원두 등록 (201 CREATED) */
     @PostMapping
     public ApiResponse<BeanResponseDto> createBean(@Valid @RequestBody BeanRequestDto requestDto) {
-        BeanResponseDto created = beanService.createBean(requestDto);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        BeanResponseDto created = beanService.createBean(memberId, requestDto);
         return ApiResponse.success(BeanSuccessCode.BEAN_CREATE_SUCCESS, created);
     }
 

--- a/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
@@ -41,7 +41,9 @@ public class BeanController {
     public ApiResponse<BeanResponseDto> updateBean(
             @PathVariable Long beanId,
             @RequestBody BeanRequestDto requestDto) {
-        BeanResponseDto updated = beanService.updateBean(beanId, requestDto);
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        BeanResponseDto updated = beanService.updateBean(beanId, memberId, requestDto);
         return ApiResponse.success(BeanSuccessCode.BEAN_UPDATE_SUCCESS, updated);
     }
 

--- a/src/main/java/com/gdg/coffee/domain/bean/domain/Bean.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/domain/Bean.java
@@ -43,6 +43,5 @@ public class Bean extends BaseTime {
         if (dto.getName() != null) this.name = dto.getName();
         if (dto.getOrigin() != null) this.origin = dto.getOrigin();
         if (dto.getDescription() != null) this.description = dto.getDescription();
-        if (dto.getCafeId() != null) this.cafeId = dto.getCafeId();
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/bean/dto/BeanRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/dto/BeanRequestDto.java
@@ -1,6 +1,7 @@
 package com.gdg.coffee.domain.bean.dto;
 
 import com.gdg.coffee.domain.bean.domain.Bean;
+import com.gdg.coffee.domain.cafe.domain.Cafe;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -22,18 +23,15 @@ public class BeanRequestDto {
 
     private String description;
 
-    @NotNull
-    private Long cafeId;
-
     /**
      * DTO -> Entity 변환
      */
-    public Bean toEntity() {
+    public Bean toEntity(Cafe cafe) {
         return Bean.builder()
                 .name(name)
                 .origin(origin)
                 .description(description)
-                .cafeId(cafeId)
+                .cafeId(cafe.getCafeId())
                 .build();
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
@@ -16,5 +16,5 @@ public interface BeanService {
     BeanResponseDto updateBean(Long beanId, Long memberId, BeanRequestDto requestDto);
 
     /** 원두 삭제 */
-    void deleteBean(Long beanId);
+    void deleteBean(Long beanId, Long memberId);
 }

--- a/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface BeanService {
     /** 원두 등록 */
-    BeanResponseDto createBean(BeanRequestDto requestDto);
+    BeanResponseDto createBean(Long memberId, BeanRequestDto requestDto);
 
     /** 카페별 원두 목록 조회 */
     List<BeanResponseDto> getBeansByCafeId(Long cafeId);

--- a/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
@@ -13,7 +13,7 @@ public interface BeanService {
     List<BeanResponseDto> getBeansByCafeId(Long cafeId);
 
     /** 원두 정보 수정 */
-    BeanResponseDto updateBean(Long beanId, BeanRequestDto requestDto);
+    BeanResponseDto updateBean(Long beanId, Long memberId, BeanRequestDto requestDto);
 
     /** 원두 삭제 */
     void deleteBean(Long beanId);

--- a/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
@@ -7,9 +7,15 @@ import com.gdg.coffee.domain.bean.exception.BeanErrorCode;
 import com.gdg.coffee.domain.bean.exception.BeanException;
 import com.gdg.coffee.domain.bean.repository.BeanRepository;
 import com.gdg.coffee.domain.bean.service.BeanService;
+import com.gdg.coffee.domain.cafe.domain.Cafe;
 import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
 import com.gdg.coffee.domain.cafe.exception.CafeException;
 import com.gdg.coffee.domain.cafe.repository.CafeRepository;
+import com.gdg.coffee.domain.member.domain.Member;
+import com.gdg.coffee.domain.member.domain.MemberRole;
+import com.gdg.coffee.domain.member.exception.MemberErrorCode;
+import com.gdg.coffee.domain.member.exception.MemberException;
+import com.gdg.coffee.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,16 +30,26 @@ public class BeanServiceImpl implements BeanService {
 
     private final BeanRepository beanRepository;
     private final CafeRepository cafeRepository;
+    private final MemberRepository memberRepository;
 
     /** 1. 원두 등록 */
     @Override
-    public BeanResponseDto createBean(BeanRequestDto dto) {
-        cafeRepository.findById(dto.getCafeId())
+    public BeanResponseDto createBean(Long memberId, BeanRequestDto dto) {
+        // Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // MemberRole 체크
+        if (member.getRole() != MemberRole.CAFE){
+            throw new BeanException(BeanErrorCode.BEAN_FORBIDDEN);
+        }
+
+        // 카페 조회
+        Cafe cafe = cafeRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
 
-        // 추후 권한 검증 추가
-
-        Bean saved = beanRepository.save(dto.toEntity());
+        Bean bean = dto.toEntity(cafe);
+        Bean saved = beanRepository.save(bean);
         return BeanResponseDto.fromEntity(saved);
     }
 
@@ -57,9 +73,7 @@ public class BeanServiceImpl implements BeanService {
                 .orElseThrow(() -> new BeanException(BeanErrorCode.BEAN_NOT_FOUND));
 
         // 추후 권한 검증 로직 수정
-        if (!bean.getCafeId().equals(requestDto.getCafeId())) {
-            throw new BeanException(BeanErrorCode.BEAN_FORBIDDEN);
-        }
+
 
         bean.update(requestDto);
         return BeanResponseDto.fromEntity(bean);

--- a/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
@@ -88,11 +88,19 @@ public class BeanServiceImpl implements BeanService {
 
     /** 4. 원두 삭제 */
     @Override
-    public void deleteBean(Long beanId) {
+    public void deleteBean(Long beanId, Long memberId) {
+        // Bean 조회
         Bean bean = beanRepository.findById(beanId)
                 .orElseThrow(() -> new BeanException(BeanErrorCode.BEAN_NOT_FOUND));
 
-        //추후 권한 검증 추가
+        // Bean 이 속한 카페 조회
+        Cafe cafe = cafeRepository.findById(bean.getCafeId())
+                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
+
+        // 권한 검사
+        if (!cafe.getMemberId().equals(memberId)) {
+            throw new BeanException(BeanErrorCode.BEAN_FORBIDDEN);
+        }
 
         beanRepository.delete(bean);
     }

--- a/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
@@ -68,12 +68,19 @@ public class BeanServiceImpl implements BeanService {
 
     /** 3. 원두 정보 수정 */
     @Override
-    public BeanResponseDto updateBean(Long beanId, BeanRequestDto requestDto) {
+    public BeanResponseDto updateBean(Long beanId, Long memberId, BeanRequestDto requestDto) {
+        // Bean 조회
         Bean bean = beanRepository.findById(beanId)
                 .orElseThrow(() -> new BeanException(BeanErrorCode.BEAN_NOT_FOUND));
 
-        // 추후 권한 검증 로직 수정
+        // Bean 이 속한 카페 조회
+        Cafe cafe = cafeRepository.findById(bean.getCafeId())
+                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
 
+        // 권한 확인
+        if (!cafe.getMemberId().equals(memberId)) {
+            throw new BeanException(BeanErrorCode.BEAN_FORBIDDEN);
+        }
 
         bean.update(requestDto);
         return BeanResponseDto.fromEntity(bean);

--- a/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
@@ -6,6 +6,7 @@ import com.gdg.coffee.domain.cafe.dto.CafeResponseDto;
 import com.gdg.coffee.domain.cafe.exception.CafeSuccessCode;
 import com.gdg.coffee.domain.cafe.service.CafeService;
 import com.gdg.coffee.global.common.response.ApiResponse;
+import com.gdg.coffee.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,8 @@ public class CafeController {
     /** 1. 카페 생성 (201 Created) */
     @PostMapping
     public ApiResponse<CafeResponseDto> createCafe(@RequestBody @Valid CafeRequestDto requestDto) {
-        CafeResponseDto created = cafeService.createCafe(requestDto);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        CafeResponseDto created = cafeService.createCafe(memberId, requestDto);
         return ApiResponse.success(CafeSuccessCode.CAFE_CREATE_SUCCESS, created);
     }
 
@@ -45,8 +47,9 @@ public class CafeController {
     @PutMapping("/{cafeId}")
     public ApiResponse<CafeResponseDto> updateCafe(
             @PathVariable Long cafeId,
-            @RequestBody @Valid CafeRequestDto requestDto) {
-        CafeResponseDto updated = cafeService.updateCafe(cafeId, requestDto);
+            @RequestBody CafeRequestDto requestDto) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        CafeResponseDto updated = cafeService.updateCafe(cafeId, memberId, requestDto);
         return ApiResponse.success(CafeSuccessCode.CAFE_UPDATE_SUCCESS, updated);
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
@@ -1,4 +1,3 @@
-// src/main/java/com/gdg/coffee/cafe/controller/CafeController.java
 package com.gdg.coffee.domain.cafe.controller;
 
 import com.gdg.coffee.domain.cafe.dto.CafeRequestDto;
@@ -8,12 +7,15 @@ import com.gdg.coffee.domain.cafe.service.CafeService;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/cafes")
@@ -38,7 +40,8 @@ public class CafeController {
 
     /** 3. 전체 카페 목록 조회 (200 OK)*/
     @GetMapping
-    public ApiResponse<Page<CafeResponseDto>> getAllCafes(Pageable pageable) {
+    public ApiResponse<Page<CafeResponseDto>> getAllCafes(
+            @PageableDefault(size = Integer.MAX_VALUE) Pageable pageable) {
         Page<CafeResponseDto> page = cafeService.getAllCafes(pageable);
         return ApiResponse.success(CafeSuccessCode.CAFE_GET_LIST_SUCCESS, page);
     }

--- a/src/main/java/com/gdg/coffee/domain/cafe/domain/Cafe.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/domain/Cafe.java
@@ -20,9 +20,8 @@ public class Cafe extends BaseTime {
     @Column(name = "cafe_id")
     private Long cafeId;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     @Column(nullable = false, length = 255)
     private String name;

--- a/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeRequestDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -40,11 +41,10 @@ public class CafeRequestDto {
 
     /**
      * DTO → Entity 변환 메서드
-     * @param member FK로 참조할 Member 엔티티 (Controller나 Service에서 조회 후 주입)
      */
-    public Cafe toEntity(Member member) {
+    public Cafe toEntity(Long memberId) {
         return Cafe.builder()
-                .member(member)  // memberId가 아닌 member 객체 사용
+                .memberId(memberId)  // memberId가 아닌 member 객체 사용
                 .name(name)
                 .address(address)
                 .detailAddress(detailAddress)

--- a/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeRequestDto.java
@@ -11,9 +11,6 @@ import lombok.*;
 @AllArgsConstructor
 public class CafeRequestDto {
 
-    @NotNull(message = "소유 회원 ID는 필수입니다.")
-    private Long memberId;
-
     @NotBlank @Size(max = 255)
     private String name;
 

--- a/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeResponseDto.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/dto/CafeResponseDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 // 카페 정보 응답 DTO
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CafeResponseDto {
@@ -25,16 +26,13 @@ public class CafeResponseDto {
     private String openHours;
     private String description;
 
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-
     /**
      * Entity → DTO 변환 메서드
      */
     public static CafeResponseDto fromEntity(Cafe cafe) {
         return CafeResponseDto.builder()
                 .cafeId(cafe.getCafeId())
-                .memberId(cafe.getMember().getId())
+                .memberId(cafe.getMemberId())
                 .name(cafe.getName())
                 .address(cafe.getAddress())
                 .detailAddress(cafe.getDetailAddress())
@@ -44,8 +42,6 @@ public class CafeResponseDto {
                 .collectSchedule(cafe.getCollectSchedule())
                 .openHours(cafe.getOpenHours())
                 .description(cafe.getDescription())
-                .createdDate(cafe.getCreatedDate())
-                .modifiedDate(cafe.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeErrorCode.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum CafeErrorCode implements ErrorResponse {
     CAFE_NOT_FOUND      (HttpStatus.NOT_FOUND,    "CAFE_NOT_FOUND",      "존재하지 않는 카페입니다."),
     CAFE_INVALID_INPUT  (HttpStatus.BAD_REQUEST,  "CAFE_INVALID_INPUT",  "잘못된 카페 요청입니다."),
-    CAFE_FORBIDDEN      (HttpStatus.FORBIDDEN,    "CAFE_FORBIDDEN",      "이 카페에 대한 권한이 없습니다.");
+    CAFE_FORBIDDEN      (HttpStatus.FORBIDDEN,    "CAFE_FORBIDDEN",      "이 카페에 대한 권한이 없습니다."),
+    CAFE_DUPLICATE      (HttpStatus.FORBIDDEN,    "CAFE_DUPLICATE",      "이미 카페가 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
@@ -3,6 +3,8 @@ package com.gdg.coffee.domain.cafe.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.gdg.coffee.domain.cafe.domain.Cafe;
 
+import java.util.Optional;
+
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
-    // 필요 시 커스텀 조회 메서드 추가 가능
+    Optional<Cafe> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 public interface CafeService {
 
     /** 카페 신규 등록 */
-    CafeResponseDto createCafe(CafeRequestDto requestDto);
+    CafeResponseDto createCafe(Long memberId, CafeRequestDto requestDto);
 
     /** 단건 조회 */
     CafeResponseDto getCafe(Long cafeId);
@@ -17,5 +17,5 @@ public interface CafeService {
     Page<CafeResponseDto> getAllCafes(Pageable pageable);
 
     /** 정보 수정 */
-    CafeResponseDto updateCafe(Long cafeId, CafeRequestDto requestDto);
+    CafeResponseDto updateCafe(Long cafeId, Long memberId, CafeRequestDto requestDto);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -36,7 +36,6 @@ public class CafeServiceImpl implements CafeService {
     @Transactional
     public CafeResponseDto createCafe(Long memberId, CafeRequestDto request) {
         // Member 조회
-        log.info(String.valueOf(memberId));
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -44,6 +43,13 @@ public class CafeServiceImpl implements CafeService {
         if (member.getRole() != MemberRole.CAFE) {
             throw new CafeException(CafeErrorCode.CAFE_FORBIDDEN);
         }
+
+        // 카페 중복 체크
+        cafeRepository.findByMemberId(memberId)
+                .ifPresent(cafe -> {
+                    throw new CafeException(CafeErrorCode.CAFE_DUPLICATE);
+                });
+
         Cafe cafe = request.toEntity(memberId);
 
         Cafe saved = cafeRepository.save(cafe);

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -7,6 +7,7 @@ import com.gdg.coffee.domain.member.domain.MemberRole;
 import com.gdg.coffee.domain.member.exception.MemberErrorCode;
 import com.gdg.coffee.domain.member.exception.MemberException;
 import com.gdg.coffee.domain.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class CafeServiceImpl implements CafeService {
 
     private final CafeRepository cafeRepository;
@@ -34,15 +36,16 @@ public class CafeServiceImpl implements CafeService {
     @Transactional
     public CafeResponseDto createCafe(Long memberId, CafeRequestDto request) {
         // Member 조회
+        log.info(String.valueOf(memberId));
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // MemberRole 체크
-        if(member.getRole() != MemberRole.CAFE) {
+        if (member.getRole() != MemberRole.CAFE) {
             throw new CafeException(CafeErrorCode.CAFE_FORBIDDEN);
         }
-        Cafe cafe = request.toEntity(member);
-        // DB에 저장 및 반환
+        Cafe cafe = request.toEntity(memberId);
+
         Cafe saved = cafeRepository.save(cafe);
         return CafeResponseDto.fromEntity(saved);
     }
@@ -61,12 +64,21 @@ public class CafeServiceImpl implements CafeService {
     @Override
     @Transactional(readOnly = true)
     public Page<CafeResponseDto> getAllCafes(Pageable pageable) {
-        throw new UnsupportedOperationException("getCafesByMember is not implemented yet");
+        Page<Cafe> cafes = cafeRepository.findAll(pageable);
+        return cafes.map(CafeResponseDto::fromEntity);
     }
 
     /** 정보 수정 */
     @Override
     public CafeResponseDto updateCafe(Long cafeId, Long memberId, CafeRequestDto requestDto) {
-        throw new UnsupportedOperationException("updateCafe is not implemented yet");
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
+
+        if (!cafe.getMemberId().equals(memberId)) {
+            throw new CafeException(CafeErrorCode.CAFE_FORBIDDEN);
+        }
+
+        cafe.update(requestDto);          // dto 필드가 null 이면 유지
+        return CafeResponseDto.fromEntity(cafe);
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -3,6 +3,7 @@ package com.gdg.coffee.domain.cafe.service.impl;
 import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
 import com.gdg.coffee.domain.cafe.exception.CafeException;
 import com.gdg.coffee.domain.member.domain.Member;
+import com.gdg.coffee.domain.member.domain.MemberRole;
 import com.gdg.coffee.domain.member.exception.MemberErrorCode;
 import com.gdg.coffee.domain.member.exception.MemberException;
 import com.gdg.coffee.domain.member.repository.MemberRepository;
@@ -31,11 +32,15 @@ public class CafeServiceImpl implements CafeService {
     /** 카페 등록*/
     @Override
     @Transactional
-    public CafeResponseDto  createCafe(CafeRequestDto request) {
+    public CafeResponseDto createCafe(Long memberId, CafeRequestDto request) {
         // Member 조회
-        Member member = memberRepository.findById(request.getMemberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
+        // MemberRole 체크
+        if(member.getRole() != MemberRole.CAFE) {
+            throw new CafeException(CafeErrorCode.CAFE_FORBIDDEN);
+        }
         Cafe cafe = request.toEntity(member);
         // DB에 저장 및 반환
         Cafe saved = cafeRepository.save(cafe);
@@ -52,7 +57,7 @@ public class CafeServiceImpl implements CafeService {
         return CafeResponseDto.fromEntity(cafe);
     }
 
-    /** 회원이 보유한 카페 목록(페이지네이션) */
+    /** 카페 목록(페이지네이션) */
     @Override
     @Transactional(readOnly = true)
     public Page<CafeResponseDto> getAllCafes(Pageable pageable) {
@@ -61,7 +66,7 @@ public class CafeServiceImpl implements CafeService {
 
     /** 정보 수정 */
     @Override
-    public CafeResponseDto updateCafe(Long cafeId, CafeRequestDto requestDto) {
+    public CafeResponseDto updateCafe(Long cafeId, Long memberId, CafeRequestDto requestDto) {
         throw new UnsupportedOperationException("updateCafe is not implemented yet");
     }
 }

--- a/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
@@ -38,7 +38,9 @@ public class SecurityConfig {
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
                                         "/h2/**",
-                                        "/error"
+                                        "/error",
+
+                                        "/api/cafes/**"
                                 ).permitAll()
                                 .requestMatchers("/api/member/info").hasRole("USER")
                                 //.requestMatchers("/**").permitAll()     // 임시

--- a/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                                 ).permitAll()
                                 .requestMatchers("/api/member/info").hasRole("USER")
                                 .requestMatchers(HttpMethod.GET, "/api/cafes/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/beans**").permitAll()
                                 //.requestMatchers("/**").permitAll()     // 임시
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.gdg.coffee.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -38,11 +39,10 @@ public class SecurityConfig {
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
                                         "/h2/**",
-                                        "/error",
-
-                                        "/api/cafes/**"
+                                        "/error"
                                 ).permitAll()
                                 .requestMatchers("/api/member/info").hasRole("USER")
+                                .requestMatchers(HttpMethod.GET, "/api/cafes/**").permitAll()
                                 //.requestMatchers("/**").permitAll()     // 임시
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/gdg/coffee/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gdg/coffee/global/security/jwt/JwtAuthenticationFilter.java
@@ -50,6 +50,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(httpServletRequest);
         log.info("BearerToken: {}", token);
 
+        /**
+        * 토큰이 아예 없으면 검증하지 않고 다음 필터로 진행
+        * 로그인 하지 않은 사용자가 접근 할 수 있어야하는 api도 막아버려서 추가
+        */
+        if (token == null) {
+            filterChain.doFilter(httpServletRequest, httpServletResponse);
+            return;
+        }
+
         try{
             // 토큰 유효성 검사 및 인증 객체 설정
             if (token != null && jwtTokenProvider.isValidToken(token)){


### PR DESCRIPTION
## 🍃 관련이슈
- Resolved : #25 

## 🌱 변경사항

- SecurityConfig : 조회만 permitAll, 나머지 JWT 인증

- CafeService / BeanService : memberId → JWT 추출 → cafeId 매핑 후 권한 검증

- CafeController / BeanController : Request에서 memberId·cafeId 제거, SecurityUtil 사용

- DTO / Entity 빌더 수정 : memberId 필드 타입 일치, null-safe 업데이트 메서드

- CAFE_DUPLICATE ErrorCode 추가

- 한 사용자가 하나의 카페만 가질 수 있도록 검증