### PR TITLE
[Refactor] API 경로 정리 및 Swagger 설명 문서화

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gdg/coffee/domain/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import com.gdg.coffee.domain.auth.exception.AuthSuccessCode;
 import com.gdg.coffee.domain.auth.service.AuthService;
 import com.gdg.coffee.domain.auth.service.GoogleOAuthService;
 import com.gdg.coffee.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -25,24 +29,44 @@ public class AuthController {
     private final AuthService authService;
     private final GoogleOAuthService googleOAuthService;
 
+    @Operation(summary = "[구현완료] 일반 회원가입", description = """
+    ## 일반 회원 가입을 수행합니다.
+    - 이메일, 비밀번호 등의 정보를 입력하여 회원가입합니다.
+    - 회원가입 완료 시 사용자 정보와 함께 응답됩니다.
+    """)
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<MemberRegisterResponseDto>> register(@RequestBody MemberRegisterRequestDto request) {
         MemberRegisterResponseDto response = authService.register(request);
         return new ResponseEntity<>(ApiResponse.success(AuthSuccessCode.REGISTER_SUCCESS, response), HttpStatus.CREATED);
     }
 
+    @Operation(summary = "[구현완료] 일반 로그인", description = """
+    ## 일반 사용자 로그인을 수행합니다.
+    - 이메일과 비밀번호를 기반으로 로그인합니다.
+    - 성공 시 액세스 토큰과 리프레시 토큰을 응답합니다.
+    """)
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<MemberLoginResponseDto>> login(@RequestBody MemberLoginRequestDto request) {
         MemberLoginResponseDto response = authService.login(request);
         return new ResponseEntity<>(ApiResponse.success(AuthSuccessCode.LOGIN_SUCCESS, response), HttpStatus.OK);
     }
 
+    @Operation(summary = "[구현완료] 액세스 토큰 재발급", description = """
+    ## 리프레시 토큰을 사용하여 액세스 토큰을 재발급합니다.
+    - 만료된 액세스 토큰을 갱신하기 위해 사용합니다.
+    - 유효한 리프레시 토큰이 필요합니다.
+    """)
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<String>> refreshAccessToken(@RequestBody RefreshTokenRequestDto request) {
         String newAccessToken = authService.refreshAccessToken(request.getRefreshToken());
         return new ResponseEntity<>(ApiResponse.success(AuthSuccessCode.TOKEN_REFRESH_SUCCESS, newAccessToken), HttpStatus.OK);
     }
 
+    @Operation(summary = "[구현완료] 구글 로그인 (프론트 연동)", description = """
+    ## 구글 OAuth 인증 코드를 사용하여 로그인합니다.
+    - 프론트엔드에서 받은 authorizationCode를 사용해 구글 로그인 절차를 수행합니다.
+    - 구글 계정이 기존 회원 정보와 연동되어 있다면 로그인 처리됩니다.
+    """)
     @PostMapping("/login/google")
     public ResponseEntity<ApiResponse<MemberLoginResponseDto>> loginGoogle(@RequestBody GoogleOAuthRequestDto requestBody) {
         String authorizationCode = requestBody.getAuthorizationCode();
@@ -50,6 +74,11 @@ public class AuthController {
         return new ResponseEntity<>(ApiResponse.success(AuthSuccessCode.LOGIN_SUCCESS, response), HttpStatus.OK);
     }
 
+    @Operation(summary = "[구현완료] 구글 콜백", description = """
+    ## 구글 OAuth 로그인 콜백입니다.
+    - 구글 로그인 승인 후 리디렉션되는 엔드포인트입니다.
+    - Authorization Code를 통해 사용자 인증 및 로그인 처리를 수행합니다.
+    """)
     @GetMapping("/google/callback")
     public ResponseEntity<ApiResponse<MemberLoginResponseDto>> googleCallback(@RequestParam("code") String code) {
         MemberLoginResponseDto response = googleOAuthService.loginGoogle(code);

--- a/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/controller/BeanController.java
@@ -4,15 +4,23 @@ import com.gdg.coffee.domain.bean.dto.BeanRequestDto;
 import com.gdg.coffee.domain.bean.dto.BeanResponseDto;
 import com.gdg.coffee.domain.bean.exception.BeanSuccessCode;
 import com.gdg.coffee.domain.bean.service.BeanService;
+import com.gdg.coffee.domain.cafe.domain.Cafe;
+import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
+import com.gdg.coffee.domain.cafe.exception.CafeException;
+import com.gdg.coffee.domain.cafe.repository.CafeRepository;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
+@Tag(name = "Bean", description = "원두 관련 API")
 @RestController
 @RequestMapping("/api/beans")
 @RequiredArgsConstructor
@@ -20,9 +28,16 @@ import java.util.List;
 public class BeanController {
 
     private final BeanService beanService;
+    private final CafeRepository cafeRepository;
 
     /** 1. 원두 등록 (201 CREATED) */
     @PostMapping
+    @Operation(summary = "[구현완료] 원두 등록", description = """
+    ## 카페 관리자가 새로운 원두를 등록합니다.
+    - 요청 본문에는 원두 이름, 원산지, 설명이 포함됩니다.
+    - 로그인된 카페 사용자만 등록할 수 있습니다.
+    - 등록된 원두 정보가 응답으로 반환됩니다.
+    """)
     public ApiResponse<BeanResponseDto> createBean(@Valid @RequestBody BeanRequestDto requestDto) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         BeanResponseDto created = beanService.createBean(memberId, requestDto);
@@ -30,14 +45,25 @@ public class BeanController {
     }
 
     /** 2. 카페별 원두 목록 조회 (200 OK) */
-    @GetMapping("/{cafeId}")
-    public ApiResponse<List<BeanResponseDto>> getBeansByCafe(@PathVariable Long cafeId) {
-        List<BeanResponseDto> list = beanService.getBeansByCafeId(cafeId);
+    @GetMapping
+    @Operation(summary = "[구현완료] 카페별 원두 목록 조회", description = """
+    ## 로그인한 카페 사용자의 원두 목록을 조회합니다.
+    - 회원의 memberId를 통해 해당 카페의 원두를 가져옵니다.
+    - 응답으로 원두 목록을 반환합니다.
+    """)
+    public ApiResponse<List<BeanResponseDto>> getBeansByCafe() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        List<BeanResponseDto> list = beanService.getBeansByCafe(memberId);
         return ApiResponse.success(BeanSuccessCode.BEAN_LIST_SUCCESS, list);
     }
 
     /** 3. 원두 정보 수정 (200 OK) */
     @PutMapping("/{beanId}")
+    @Operation(summary = "[구현완료] 원두 정보 수정", description = """
+    ## 등록된 원두의 정보를 수정합니다.
+    - 수정 가능한 필드는 이름, 원산지, 설명입니다.
+    - 요청자는 해당 원두를 등록한 카페의 사용자여야 합니다.
+    """)
     public ApiResponse<BeanResponseDto> updateBean(
             @PathVariable Long beanId,
             @RequestBody BeanRequestDto requestDto) {
@@ -49,6 +75,11 @@ public class BeanController {
 
     /** 4. 원두 삭제 (200 OK) */
     @DeleteMapping("/{beanId}")
+    @Operation(summary = "[구현완료] 원두 삭제", description = """
+    ## 원두 정보를 삭제합니다.
+    - 삭제는 해당 원두를 등록한 카페의 사용자만 가능합니다.
+    - 삭제 성공 시 응답 본문 없이 성공 코드만 반환됩니다.
+    """)
     public ApiResponse<Void> deleteBean(@PathVariable Long beanId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         beanService.deleteBean(beanId, memberId);

--- a/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/BeanService.java
@@ -2,6 +2,7 @@ package com.gdg.coffee.domain.bean.service;
 
 import com.gdg.coffee.domain.bean.dto.BeanRequestDto;
 import com.gdg.coffee.domain.bean.dto.BeanResponseDto;
+import com.gdg.coffee.domain.member.domain.Member;
 
 import java.util.List;
 
@@ -10,7 +11,8 @@ public interface BeanService {
     BeanResponseDto createBean(Long memberId, BeanRequestDto requestDto);
 
     /** 카페별 원두 목록 조회 */
-    List<BeanResponseDto> getBeansByCafeId(Long cafeId);
+    List<BeanResponseDto> getBeansByCafe(Long memberId);
+
 
     /** 원두 정보 수정 */
     BeanResponseDto updateBean(Long beanId, Long memberId, BeanRequestDto requestDto);

--- a/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/bean/service/impl/BeanServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -56,12 +57,12 @@ public class BeanServiceImpl implements BeanService {
     /** 2. 카페별 원두 목록 조회 */
     @Override
     @Transactional(readOnly = true)
-    public List<BeanResponseDto> getBeansByCafeId(Long cafeId) {
-        cafeRepository.findById(cafeId)
+    public List<BeanResponseDto> getBeansByCafe(Long memberId) {
+        Cafe cafe = cafeRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
 
         // 원두 조회 및 DTO 변환
-        return beanRepository.findAllByCafeId(cafeId).stream()
+        return beanRepository.findAllByCafeId(cafe.getId()).stream()
                 .map(BeanResponseDto::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
@@ -6,6 +6,8 @@ import com.gdg.coffee.domain.cafe.exception.CafeSuccessCode;
 import com.gdg.coffee.domain.cafe.service.CafeService;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+@Tag(name = "Cafe", description = "카페 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +28,12 @@ public class CafeController {
 
     /** 1. 카페 생성 (201 Created) */
     @PostMapping
+    @Operation(summary = "[구현완료] 카페 등록", description = """
+        ## 카페 사용자로 로그인한 회원이 카페를 등록합니다.
+        - 요청 본문에는 카페 이름, 주소, 상세주소, 연락처, 영업시간, 설명, 수거 일정 등이 포함됩니다.
+        - 로그인한 회원의 memberId를 기반으로 카페가 등록됩니다.
+        - 한 명의 회원은 하나의 카페만 등록할 수 있습니다.
+        """)
     public ApiResponse<CafeResponseDto> createCafe(@RequestBody @Valid CafeRequestDto requestDto) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         CafeResponseDto created = cafeService.createCafe(memberId, requestDto);
@@ -33,6 +42,11 @@ public class CafeController {
 
     /** 2. 단건 조회 (200 OK) */
     @GetMapping("/{cafeId}")
+    @Operation(summary = "[구현완료] 카페 단건 조회", description = """
+        ## 특정 ID에 해당하는 카페 정보를 조회합니다.
+        - 누구나 접근 가능하며, 카페 상세 정보를 확인할 수 있습니다.
+        - 카페 ID는 URL 경로 변수로 전달됩니다.
+        """)
     public ApiResponse<CafeResponseDto> getCafe(@PathVariable Long cafeId) {
         CafeResponseDto dto = cafeService.getCafe(cafeId);
         return ApiResponse.success(CafeSuccessCode.CAFE_GET_SUCCESS, dto);
@@ -40,6 +54,11 @@ public class CafeController {
 
     /** 3. 전체 카페 목록 조회 (200 OK)*/
     @GetMapping
+    @Operation(summary = "[구현완료] 전체 카페 목록 조회", description = """
+        ## 등록된 모든 카페 목록을 조회합니다.
+        - 페이징 처리를 지원하며, size 기본값은 전체 목록입니다.
+        - 누구나 접근 가능합니다.
+        """)
     public ApiResponse<Page<CafeResponseDto>> getAllCafes(
             @PageableDefault(size = Integer.MAX_VALUE) Pageable pageable) {
         Page<CafeResponseDto> page = cafeService.getAllCafes(pageable);
@@ -47,12 +66,15 @@ public class CafeController {
     }
 
     /** 4. 정보 수정 (200 OK) */
-    @PutMapping("/{cafeId}")
-    public ApiResponse<CafeResponseDto> updateCafe(
-            @PathVariable Long cafeId,
-            @RequestBody CafeRequestDto requestDto) {
+    @PutMapping
+    @Operation(summary = "[구현완료] 카페 정보 수정", description = """
+        ## 로그인한 카페 사용자가 자신의 카페 정보를 수정합니다.
+        - 로그인된 사용자 정보(memberId)를 기준으로 본인의 카페를 조회 후 수정합니다.
+        - 입력된 필드 중 null이 아닌 값만 수정됩니다.
+        """)
+    public ApiResponse<CafeResponseDto> updateCafe(@RequestBody CafeRequestDto requestDto) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        CafeResponseDto updated = cafeService.updateCafe(cafeId, memberId, requestDto);
+        CafeResponseDto updated = cafeService.updateCafe(memberId, requestDto);
         return ApiResponse.success(CafeSuccessCode.CAFE_UPDATE_SUCCESS, updated);
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
@@ -17,5 +17,5 @@ public interface CafeService {
     Page<CafeResponseDto> getAllCafes(Pageable pageable);
 
     /** 정보 수정 */
-    CafeResponseDto updateCafe(Long cafeId, Long memberId, CafeRequestDto requestDto);
+    CafeResponseDto updateCafe(Long memberId, CafeRequestDto requestDto);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -75,13 +75,15 @@ public class CafeServiceImpl implements CafeService {
 
     /** 정보 수정 */
     @Override
-    public CafeResponseDto updateCafe(Long cafeId, Long memberId, CafeRequestDto requestDto) {
-        Cafe cafe = cafeRepository.findById(cafeId)
-                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
+    public CafeResponseDto updateCafe(Long memberId, CafeRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (!cafe.getMember().getId().equals(memberId)) {
+        if(member.getRole() != MemberRole.CAFE){
             throw new CafeException(CafeErrorCode.CAFE_FORBIDDEN);
         }
+        Cafe cafe = cafeRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
 
         cafe.update(requestDto);          // dto 필드가 null 이면 유지
         return CafeResponseDto.fromEntity(cafe);

--- a/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
@@ -5,6 +5,8 @@ import com.gdg.coffee.domain.ground.exception.CoffeeGroundSuccessCode;
 import com.gdg.coffee.domain.ground.service.CoffeeGroundService;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,15 +16,21 @@ import jakarta.validation.Valid;
 
 import java.util.List;
 
+@Tag(name = "CoffeeGround", description = "커피 찌꺼기 관련 API")
 @RestController
-@RequestMapping("/api/coffee_grounds")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CoffeeGroundController {
 
     private final CoffeeGroundService groundService;
 
     /* 1. 등록 */
-    @PostMapping
+    @PostMapping("/coffee_grounds")
+    @Operation(summary = "[구현완료] 커피 찌꺼기 등록", description = """
+        ## 카페 사용자가 커피 찌꺼기를 등록합니다.
+        - 로그인된 사용자의 memberId를 기반으로 소속된 카페를 식별합니다.
+        - 등록 시 원두 ID, 총 배출량, 메모 등을 입력받습니다.
+        """)
     public ApiResponse<CoffeeGroundResponseDto> createGround(@RequestBody @Valid CoffeeGroundRequestDto dto) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         CoffeeGroundResponseDto created = groundService.createGround(memberId, dto);
@@ -30,22 +38,35 @@ public class CoffeeGroundController {
     }
 
     /* 2. 단건 조회 */
-    @GetMapping("/{groundId}")
+    @GetMapping("/coffee_grounds/{groundId}")
+    @Operation(summary = "[구현완료] 커피 찌꺼기 단건 조회", description = """
+        ## 커피 찌꺼기 ID로 단건 상세 정보를 조회합니다.
+        - 누구나 접근 가능하며, 카페/사용자 모두 확인 가능합니다.
+        """)
     public ApiResponse<CoffeeGroundResponseDto> getGround(@PathVariable Long groundId) {
         CoffeeGroundResponseDto response = groundService.getGround(groundId);
         return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_GET_SUCCESS, response);
     }
 
     /* 3. 목록 (카페별) */
-    @GetMapping("/cafe/{cafeId}")
-    public ApiResponse<List<CoffeeGroundResponseDto>>
-    getGroundsOfCafe(@PathVariable Long cafeId) {
-        List<CoffeeGroundResponseDto> response = groundService.getGroundsOfCafe(cafeId);
+    @GetMapping("/cafe/coffee_grounds")
+    @Operation(summary = "[구현완료] 내 카페 커피 찌꺼기 목록 조회", description = """
+        ## 로그인한 카페 사용자의 소속 카페에서 등록한 찌꺼기 목록을 조회합니다.
+        - 인증된 사용자의 memberId를 기준으로 카페를 식별하여 찌꺼기를 불러옵니다.
+        """)
+    public ApiResponse<List<CoffeeGroundResponseDto>> getGroundsOfCafe() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        List<CoffeeGroundResponseDto> response = groundService.getGroundsOfCafe(memberId);
         return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_LIST_SUCCESS, response);
     }
 
     /* 4. 삭제 */
-    @DeleteMapping("/{groundId}")
+    @DeleteMapping("/coffee_grounds/{groundId}")
+    @Operation(summary = "[구현완료] 커피 찌꺼기 삭제", description = """
+        ## 커피 찌꺼기 ID를 통해 삭제합니다.
+        - 삭제는 해당 카페 소속 사용자만 수행할 수 있습니다.
+        - 인증된 사용자 정보 기반으로 검증이 이루어집니다.
+        """)
     public ApiResponse<Void> deleteGround(@PathVariable Long groundId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         groundService.deleteGround(groundId, memberId);

--- a/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
@@ -11,7 +11,7 @@ public interface CoffeeGroundService {
     CoffeeGroundResponseDto getGround(Long groundId);
 
     /** 카페별 원두 목록 조회 */
-    List<CoffeeGroundResponseDto> getGroundsOfCafe(Long cafeId);
+    List<CoffeeGroundResponseDto> getGroundsOfCafe(Long memberId);
 
     /** 원두 삭제 */
     void deleteGround(Long groundId, Long memberId);

--- a/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
@@ -14,6 +14,10 @@ import com.gdg.coffee.domain.ground.exception.CoffeeGroundErrorCode;
 import com.gdg.coffee.domain.ground.exception.CoffeeGroundException;
 import com.gdg.coffee.domain.ground.repository.CoffeeGroundRepository;
 import com.gdg.coffee.domain.ground.service.CoffeeGroundService;
+import com.gdg.coffee.domain.member.domain.Member;
+import com.gdg.coffee.domain.member.exception.MemberErrorCode;
+import com.gdg.coffee.domain.member.exception.MemberException;
+import com.gdg.coffee.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +33,7 @@ public class CoffeeGroundServiceImpl implements CoffeeGroundService {
     private final CoffeeGroundRepository groundRepo;
     private final CafeRepository cafeRepo;
     private final BeanRepository beanRepo;
+    private final MemberRepository memberRepository;
 
     @Override
     public CoffeeGroundResponseDto createGround(Long memberId,
@@ -62,11 +67,13 @@ public class CoffeeGroundServiceImpl implements CoffeeGroundService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<CoffeeGroundResponseDto> getGroundsOfCafe(Long cafeId){
-        cafeRepo.findById(cafeId)
+    public List<CoffeeGroundResponseDto> getGroundsOfCafe(Long memberId){
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Cafe cafe = cafeRepo.findByMemberId(memberId)
                 .orElseThrow(() -> new CoffeeGroundException(CafeErrorCode.CAFE_NOT_FOUND));
 
-        return groundRepo.findAllByCafeId(cafeId).stream()
+        return groundRepo.findAllByCafeId(cafe.getId()).stream()
                 .map(CoffeeGroundResponseDto::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/gdg/coffee/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/coffee/domain/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import com.gdg.coffee.domain.member.exception.MemberSuccessCode;
 import com.gdg.coffee.domain.member.service.MemberService;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Member", description = "회원 정보 관련 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/members")
@@ -21,6 +24,11 @@ public class MemberController {
 
     // 회원정보 가져오는 메서드
     @GetMapping("/info")
+    @Operation(summary = "[구현완료] 회원 정보 조회", description = """
+        ## 로그인한 사용자의 정보를 조회합니다.
+        - JWT 토큰을 통해 인증된 사용자만 접근 가능합니다.
+        - 응답에는 닉네임, 역할, 이메일 등의 회원 정보가 포함됩니다.
+        """)
     public ResponseEntity<ApiResponse<MemberInfoResponseDto>> getMemberInfo() {
         Long memberId = SecurityUtil.getCurrentMemberId();
         log.info("MemberId : {}", memberId);

--- a/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
@@ -7,6 +7,8 @@ import com.gdg.coffee.domain.pickup.service.PickupService;
 import com.gdg.coffee.global.common.response.ApiResponse;
 import com.gdg.coffee.global.security.CustomUserDetails;
 import com.gdg.coffee.global.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,65 +19,78 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Pickup", description = "커피 찌꺼기 수거 요청 관련 API")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/pickups")
+@RequestMapping("/api")
 public class PickupController {
 
     private final PickupService pickupService;
 
-    // 수거 요청 생성 - 사용자
-    @PostMapping("/{ground_id}")
+    /** 수거 요청 생성 - 사용자 */
+    @PostMapping("/pickups/{ground_id}")
+    @Operation(summary = "수거 요청 생성", description = """
+        ## 커피 찌꺼기에 대해 수거 요청을 생성합니다.
+        * 인증된 사용자만 요청할 수 있습니다.
+        * 등록 시 상태는 WAITING으로 시작합니다.
+        """)
     public ApiResponse<PickupResponseDto> createPickup(@RequestBody @Valid PickupRequestDto requestDto, @PathVariable Long ground_id) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         PickupResponseDto pickup = pickupService.createPickup(memberId, ground_id, requestDto);
         return ApiResponse.success(PickupSuccessCode.PICKUP_SUCCESS_CODE, pickup);
     }
 
-    // 수거 요청 목록 조회 - 카페
-    @GetMapping("/cafes/{cafeId}")
+    /** 수거 요청 목록 조회 - 카페 */
+    @GetMapping("/cafe/pickups")
+    @Operation(summary = "카페 수거 요청 목록 조회", description = """
+        ## 현재 로그인된 카페의 수거 요청 목록을 조회합니다.
+        * 상태(PickupStatus)에 따라 필터링할 수 있습니다.
+        """)
     public ApiResponse<List<PickupCafeSummaryDto>> getCafePickupsByStatus(
-            @PathVariable Long cafeId,
-            @RequestParam(required = false) PickupStatus status // status가 null일 수도 있으므로 optional 처리
-    ) {
-        List<PickupCafeSummaryDto> response;
-
-        if (status != null) {
-            response = pickupService.getCafePickupListByStatus(cafeId, status);
-        } else {
-            response = pickupService.getCafePickupList(cafeId);
-        }
-
-        return ApiResponse.success(PickupSuccessCode.PICKUP_GET_LIST_SUCCESS, response);
-    }
-
-    // 수거 요청 목록 조회 - 사용자
-    @GetMapping("/users/{userId}")
-    public ApiResponse<List<PickupUserSummaryDto>> getUserPickupsByStatus(
-            @PathVariable Long memberId,
             @RequestParam(required = false) PickupStatus status
     ) {
-        List<PickupUserSummaryDto> response;
-
-        if (status != null) {
-            response = pickupService.getUserPickupListByStatus(memberId, status);
-        } else {
-            response = pickupService.getUserPickupList(memberId);
-        }
+        Long cafeId = SecurityUtil.getCurrentMemberId();
+        List<PickupCafeSummaryDto> response = (status != null)
+                ? pickupService.getCafePickupListByStatus(cafeId, status)
+                : pickupService.getCafePickupList(cafeId);
 
         return ApiResponse.success(PickupSuccessCode.PICKUP_GET_LIST_SUCCESS, response);
     }
 
-    // 수거 요청 상세 보기
+    /** 수거 요청 목록 조회 - 사용자 */
+    @GetMapping("/mypage/pickups")
+    @Operation(summary = "사용자 수거 요청 목록 조회", description = """
+        ## 현재 로그인된 사용자의 수거 요청 목록을 조회합니다.
+        * 상태(PickupStatus)에 따라 필터링할 수 있습니다.
+        """)
+    public ApiResponse<List<PickupUserSummaryDto>> getUserPickupsByStatus(
+            @RequestParam(required = false) PickupStatus status
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        List<PickupUserSummaryDto> response = (status != null)
+                ? pickupService.getUserPickupListByStatus(memberId, status)
+                : pickupService.getUserPickupList(memberId);
+
+        return ApiResponse.success(PickupSuccessCode.PICKUP_GET_LIST_SUCCESS, response);
+    }
+
+    /** 수거 요청 상세 보기 */
+    @Operation(summary = "수거 요청 상세 조회", description = """
+        ## 수거 요청 ID로 수거 요청의 상세 정보를 조회합니다.
+        """)
     @GetMapping("/{pickupId}")
     public ApiResponse<PickupResponseDto> getPickupDetail(@PathVariable Long pickupId) {
         PickupResponseDto pickupDetail = pickupService.getPickupDetail(pickupId);
         return ApiResponse.success(PickupSuccessCode.PICKUP_SUCCESS_CODE, pickupDetail);
     }
 
-    // 수거 요청 상태 변경
+    /** 수거 요청 상태 변경 */
     @PutMapping("/{pickupId}/status")
+    @Operation(summary = "수거 요청 상태 변경", description = """
+        ## 수거 요청의 상태를 변경합니다.
+        * 예: WAITING → COMPLETED
+        """)
     public ApiResponse<Void> updatePickupStatus(
             @PathVariable Long pickupId,
             @RequestBody PickupStatusUpdateRequestDto requestDto
@@ -84,8 +99,12 @@ public class PickupController {
         return ApiResponse.success(PickupSuccessCode.PICKUP_STATUS_UPDATE_SUCCESS);
     }
 
-    // 수거 요청 삭제
+    /** 수거 요청 삭제 */
     @DeleteMapping("/{pickupId}")
+    @Operation(summary = "수거 요청 삭제", description = """
+        ## 수거 요청을 삭제합니다.
+        * 요청한 사용자 본인만 삭제할 수 있습니다.
+        """)
     public ApiResponse<Void> deletePickup(
             @PathVariable Long pickupId,
             @AuthenticationPrincipal CustomUserDetails userDetails


### PR DESCRIPTION
## ✅ 관련 이슈
close #34  

##  개요
- 기존에 혼재되어 있던 API 경로를 RESTful하게 정리했습니다.
- Swagger UI에서 명확하게 이해할 수 있도록 각 API에 @Operation 기반 설명을 추가했습니다.

##  주요 변경 사항
- /mypage/cafe/pickups → /cafe/pickups
- /beans/{cafeId} → 인증 기반 /beans
- @Operation(summary, description) 어노테이션 추가로 Swagger 문서화 향상

## ✅ 참고
- 기존의 PathVariable 기반 경로 일부는 인증 사용자 기반으로 변경하였습니다.
- 인증 기반 API 사용 시 SecurityUtil로부터 memberId를 추출합니다.

## 인증
- 수정된 API는 인증된 사용자만 접근 가능하도록 설정되어 있습니다.


<img width="1425" alt="image" src="https://github.com/user-attachments/assets/3ea2b01a-8f54-4a3c-9a83-cabff63ef191" />
