### PR TITLE
[Fix] 구글 소셜 로그인 로직 변경

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/auth/service/GoogleOAuthService.java
+++ b/src/main/java/com/gdg/coffee/domain/auth/service/GoogleOAuthService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -42,6 +43,21 @@ public class GoogleOAuthService {
 
     @Value("${oauth.google.user-info-uri}")
     private String userInfoUri;
+
+    /**
+     * 1) 구글 OAuth 승인 URL 생성
+     */
+    public String buildAuthorizationUri() {
+        return UriComponentsBuilder
+                .fromHttpUrl("https://accounts.google.com/o/oauth2/v2/auth")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", "openid email profile")
+                .build()
+                .toUriString();
+    }
+
 
     public MemberLoginResponseDto loginGoogle(String authorizationCode) {
         // 1. authorizationCode로 accessToken 얻기

--- a/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
@@ -33,14 +33,11 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         "/login/**",
                                         "/api/users/login/**",
-                                        "/api/auth/register",
-                                        "/api/auth/login",
-                                        "/api/auth/refresh",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
                                         "/h2/**",
                                         "/error",
-                                        "/api/auth/login/google",
+                                        "/api/auth/**",
                                         "/oauth/**"
                                 ).permitAll()
                                 .requestMatchers("/api/member/info").hasRole("USER")


### PR DESCRIPTION
## 📖 Background
기존에는 컨트롤러에서 직접 구글 인증 URL을 생성하고,
콜백에서도 POST 형태의 수동 교환 로직과 GET 콜백을 혼용해 복잡도가 높았음

## 🔀 변경 사항

1. OAuth URL 생성 로직을 서비스로 이동

    - GoogleOAuthService.buildAuthorizationUri() 메서드 추가
    - 컨트롤러는 이 메서드 호출 후 redirect만 담당

2. 컨트롤러 엔드포인트 정리

    - GET /api/auth/google → 구글 승인 페이지로 302 리다이렉트
    - GET /api/auth/google/callback → code 파라미터 받아 토큰 교환 및 JWT 발급

3. Security 설정 업데이트

    - /api/auth/**, /oauth/** 경로 전부 permitAll() 처리
    - JWT 필터는 인증이 필요한 다른 엔드포인트만 보호
    
4. 불필요한 수동 POST 로직 제거

    - POST /login/google 엔드포인트 및 @RequestBody 방식 삭제

## ✅ 테스트
브라우저에서 GET /api/auth/google 호출 → Google 로그인 화면으로 이동

로그인/동의 후 GET /api/auth/google/callback?code=<…> 요청 →
{ status:200, code:"LOGIN_SUCCESS", data:{ accessToken, refreshToken, … }} JSON 반환 확인

