### PR TITLE
[Add] API to check if the logged-in member has a cafe

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,8 @@
 services:
   app:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile
     image: jh011007/coffee-app:develop
     platform: linux/amd64
     container_name: coffee-app
@@ -10,6 +13,7 @@ services:
       - redis
     volumes:
       - /home/deehyeondeehyeon/application.yaml:/app/src/main/resources/application.yaml
+#      - ./application.yaml:/app/src/main/resources/application.yaml
     environment:
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
       SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}

--- a/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
@@ -78,4 +78,39 @@ public class CafeController {
         CafeResponseDto updated = cafeService.updateCafe(memberId, requestDto);
         return ApiResponse.success(CafeSuccessCode.CAFE_UPDATE_SUCCESS, updated);
     }
+
+    @GetMapping("/me")
+    @Operation(
+            summary = "내 카페 정보 조회",
+            description = """
+            현재 로그인한 사용자의 카페 정보를 반환합니다.
+            
+            - JWT 토큰을 통해 인증된 사용자만 호출할 수 있습니다.
+            - 사용자가 카페를 보유하지 않은 경우, 404 예외(CAFE_NOT_FOUND)가 발생합니다.
+            - 응답 데이터에는 카페 이름, 주소, 설명, 연락처 등의 상세 정보가 포함됩니다.
+            """
+    )
+    public ApiResponse<CafeResponseDto> getCafeInfo() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        CafeResponseDto cafeInfo = cafeService.getCafeInfo(memberId);
+        return ApiResponse.success(CafeSuccessCode.CAFE_GET_SUCCESS, cafeInfo);
+    }
+
+    @GetMapping("/me/exists")
+    @Operation(
+            summary = "내 카페 존재 여부 확인",
+            description = """
+            현재 로그인한 사용자가 카페를 등록했는지 여부를 반환합니다.
+        
+            - true: 카페가 있음
+            - false: 카페가 없음
+            - JWT 인증이 필요합니다.
+            """
+    )
+    public ApiResponse<Boolean> hasCafe() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        Boolean hasCafe = cafeService.existsByMemberId(memberId);
+        return ApiResponse.success(CafeSuccessCode.CAFE_EXIST_CHECK_SUCCESS, hasCafe);
+    }
+
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeErrorCode.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeErrorCode.java
@@ -7,7 +7,8 @@ public enum CafeErrorCode implements ErrorResponse {
     CAFE_NOT_FOUND      (HttpStatus.NOT_FOUND,    "CAFE_NOT_FOUND",      "존재하지 않는 카페입니다."),
     CAFE_INVALID_INPUT  (HttpStatus.BAD_REQUEST,  "CAFE_INVALID_INPUT",  "잘못된 카페 요청입니다."),
     CAFE_FORBIDDEN      (HttpStatus.FORBIDDEN,    "CAFE_FORBIDDEN",      "이 카페에 대한 권한이 없습니다."),
-    CAFE_DUPLICATE      (HttpStatus.FORBIDDEN,    "CAFE_DUPLICATE",      "이미 카페가 존재합니다.");
+    CAFE_DUPLICATE      (HttpStatus.FORBIDDEN,    "CAFE_DUPLICATE",      "이미 카페가 존재합니다."),
+    CAFE_NOT_FOUND_BY_MEMBER(HttpStatus.NOT_FOUND, "CAFE_NOT_FOUND_BY_MEMBER", "해당 회원의 카페가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeSuccessCode.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeSuccessCode.java
@@ -7,7 +7,9 @@ public enum CafeSuccessCode implements SuccessResponse {
     CAFE_CREATE_SUCCESS   (HttpStatus.CREATED, "CAFE_CREATE_SUCCESS",    "카페가 성공적으로 생성되었습니다."),
     CAFE_GET_SUCCESS      (HttpStatus.OK,      "CAFE_GET_SUCCESS",       "카페 정보를 성공적으로 조회했습니다."),
     CAFE_GET_LIST_SUCCESS (HttpStatus.OK,      "CAFE_GET_LIST_SUCCESS",  "카페 목록을 성공적으로 조회했습니다."),
-    CAFE_UPDATE_SUCCESS   (HttpStatus.OK,      "CAFE_UPDATE_SUCCESS",    "카페 정보가 성공적으로 수정되었습니다.");
+    CAFE_UPDATE_SUCCESS   (HttpStatus.OK,      "CAFE_UPDATE_SUCCESS",    "카페 정보가 성공적으로 수정되었습니다."),
+    CAFE_EXIST_CHECK_SUCCESS(HttpStatus.OK, "CAFE_EXIST_CHECK_SUCCESS", "카페 존재 여부를 성공적으로 확인했습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
     Optional<Cafe> findByMemberId(Long memberId);
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
@@ -13,6 +13,11 @@ public interface CafeService {
     /** 단건 조회 */
     CafeResponseDto getCafe(Long cafeId);
 
+    /** 내 카페 조회*/
+    CafeResponseDto getCafeInfo(Long memberId);
+
+    Boolean existsByMemberId(Long memberId);
+
     /** 회원이 보유한 카페 목록(페이지네이션) */
     Page<CafeResponseDto> getAllCafes(Pageable pageable);
 

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -65,6 +65,23 @@ public class CafeServiceImpl implements CafeService {
         return CafeResponseDto.fromEntity(cafe);
     }
 
+    @Override
+    public CafeResponseDto getCafeInfo(Long memberId) {
+        Cafe cafe = cafeRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
+        return CafeResponseDto.fromEntity(cafe);
+    }
+
+    @Override
+    public Boolean existsByMemberId(Long memberId) {
+        boolean exists = cafeRepository.existsByMemberId(memberId);
+        if (!exists) {
+            throw new CafeException(CafeErrorCode.CAFE_NOT_FOUND_BY_MEMBER);
+        }
+        return true;
+    }
+
+
     /** 카페 목록(페이지네이션) */
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 개요
사용자가 자신의 카페가 존재하는지 확인할 수 있는 API를 추가했습니다.

## 🔧 변경사항
- GET `/api/cafes/me/exists` 엔드포인트 추가
- CafeService에 `existsByMemberId` 메서드 구현
- CafeRepository에 `existsByMemberId()` 쿼리 메서드 추가
- CafeSuccessCode에 `CAFE_EXIST_CHECK_SUCCESS` 코드 추가

## ✅ 테스트
- 카페가 있는 사용자와 없는 사용자 케이스를 각각 테스트
- Swagger에서 정상 응답 확인

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/17729e4a-7100-4333-8939-c511ac12cf40" />
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/c66c448e-4a91-48e6-b62f-27ccc365cfd3" />



## 관련 이슈
Closes #46
