### PR TITLE
[Fix] 픽업 조회 데이터 매핑 및 CoffeeGround 관련 로직/오류 수정

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/ground/dto/CoffeeGroundRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/dto/CoffeeGroundRequestDto.java
@@ -24,7 +24,7 @@ public class CoffeeGroundRequestDto {
                 .bean(bean)
                 .startDateTime(startDateTime.toLocalDate().atStartOfDay())
                 .totalAmount(amount)
-                .remainingAmount(0F)
+                .remainingAmount(amount)
                 .note(note)
                 .status(CoffeeGroundStatus.WAITING)
                 .build();

--- a/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
@@ -15,4 +15,6 @@ public interface CoffeeGroundService {
 
     /** 원두 삭제 */
     void deleteGround(Long groundId, Long memberId);
+
+    void decreaseAmountAndCheckStatus(Long groundId, float amountDecreased);
 }

--- a/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
@@ -7,6 +7,7 @@ import com.gdg.coffee.domain.cafe.domain.Cafe;
 import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
 import com.gdg.coffee.domain.cafe.repository.CafeRepository;
 import com.gdg.coffee.domain.ground.domain.CoffeeGround;
+import com.gdg.coffee.domain.ground.domain.CoffeeGroundStatus;
 import com.gdg.coffee.domain.ground.dto.CoffeeGroundRequestDto;
 import com.gdg.coffee.domain.ground.dto.CoffeeGroundResponseDto;
 import com.gdg.coffee.domain.ground.exception.CoffeeGroundErrorCode;
@@ -89,5 +90,28 @@ public class CoffeeGroundServiceImpl implements CoffeeGroundService {
         }
 
         groundRepo.delete(ground);
+    }
+    /**
+     * 원두 수거 요청 완료 시, 원두의 남은 양을 감소시키고 상태를 확인하는 메서드
+     * @param groundId 원두 ID
+     * @param amountDecreased 감소할 양
+     */
+    @Override
+    @Transactional
+    public void decreaseAmountAndCheckStatus(Long groundId, float amountDecreased){
+        CoffeeGround ground = groundRepo.findById(groundId)
+                .orElseThrow(() -> new CoffeeGroundException(CoffeeGroundErrorCode.GROUND_NOT_FOUND));
+
+        // remainingAmount를 감소
+        float newAmount = ground.getRemainingAmount() - amountDecreased;
+
+        ground.setRemainingAmount(newAmount); // Setter 사용
+
+        // 감소 후 잔여량에 따라 상태(status)를 업데이트
+        if (newAmount == 0) {
+            ground.setStatus(CoffeeGroundStatus.COMPLETED); // CoffeeGroundStatus enum 사용
+        } else {
+            ground.setStatus(CoffeeGroundStatus.IN_PROGRESS); // CoffeeGroundStatus enum 사용
+        }
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
@@ -64,9 +64,9 @@ public class PickupController {
             @RequestParam(value = "status", required = false) PickupStatus status
     ) {
         // SecurityUtil 에서 카페 ID를 꺼내옵니다
-        Long cafeId = SecurityUtil.getCurrentMemberId();
+        Long memberId = SecurityUtil.getCurrentMemberId();
         List<PickupCafeSummaryDto> pickups =
-                pickupService.getCafePickupList(cafeId, status);
+                pickupService.getCafePickupList(memberId, status);
 
         return ApiResponse.success(
                 PickupSuccessCode.PICKUP_GET_LIST_SUCCESS,
@@ -124,7 +124,8 @@ public class PickupController {
             @PathVariable Long pickupId,
             @RequestBody PickupStatusUpdateRequestDto requestDto
     ) {
-        pickupService.updatePickupStatus(pickupId, requestDto.getStatus());
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        pickupService.updatePickupStatus(pickupId, memberId, requestDto.getStatus());
         return ApiResponse.success(PickupSuccessCode.PICKUP_STATUS_UPDATE_SUCCESS);
     }
 

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupCafeSummaryDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupCafeSummaryDto.java
@@ -6,23 +6,26 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class PickupCafeSummaryDto {
 
+    private Long pickupId;             // 수거 신청 ID
     private String requesterName;       // 요청자 이름
-    private LocalDate requestDate;      // 신청일
     private LocalDate pickupDate;       // 수거 희망일
+    private LocalDateTime requestDate;      // 신청일
     private String beanName;           // 원두 종류 (ex: 에티오피아 예가체프)
     private float amount;               // 요청량 (ex: 3.5L)
     private PickupStatus status;        // 상태 (대기 중, 수락됨, 완료됨, 거절됨)
 
     public static PickupCafeSummaryDto fromEntity(Pickup pickup) {
         return PickupCafeSummaryDto.builder()
+                .pickupId(pickup.getId())
                 .requesterName(pickup.getMember().getUsername())
-                .requestDate(pickup.getCreatedDate().toLocalDate())
+                .requestDate(pickup.getCreatedDate())
                 .pickupDate(pickup.getPickupDate())
                 //.beanName(pickup.getGround().getBean().getName())
                 .amount(pickup.getAmount())

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupRequestDto.java
@@ -19,6 +19,7 @@ public class PickupRequestDto {
         return Pickup.builder()
                 .member(member)
                 .ground(ground)
+                .status(PickupStatus.PENDING) // 초기 상태는 대기 중
                 .pickupDate(requestDto.getPickupDate())
                 .amount(requestDto.getAmount())
                 .message(requestDto.getMessage())

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupResponseDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupResponseDto.java
@@ -19,6 +19,7 @@ public class PickupResponseDto {
     private float amount;               // 수거 양
     private String message;             // 수거 요청 메시지 (선택)
     private LocalDate pickupDate;       // 희망 수거일
+    private PickupStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -30,6 +31,7 @@ public class PickupResponseDto {
                 .amount(pickup.getAmount())
                 .message(pickup.getMessage())
                 .pickupDate(pickup.getPickupDate())
+                .status(pickup.getStatus())
                 .createdAt(pickup.getCreatedDate())
                 .updatedAt(pickup.getModifiedDate())
                 .build();

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupResponseDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupResponseDto.java
@@ -25,6 +25,7 @@ public class PickupResponseDto {
     public static PickupResponseDto fromEntity(Pickup pickup) {
         return PickupResponseDto.builder()
                 .pickupId(pickup.getId())
+                .groundId(pickup.getGround().getGroundId())
                 .memberId(pickup.getMember().getId())
                 .amount(pickup.getAmount())
                 .message(pickup.getMessage())

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupUserSummaryDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupUserSummaryDto.java
@@ -6,15 +6,17 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class PickupUserSummaryDto {
 
+    private Long pickupId;          // 수거 요청 ID
     private String cafeName;       // 요청자 이름
-    private LocalDate requestDate;      // 신청일
     private LocalDate pickupDate;       // 수거 희망일
+    private LocalDateTime requestDate;      // 신청일
     private String beanName;           // 원두 종류 (ex: 에티오피아 예가체프)
     private float amount;               // 요청량 (ex: 3.5L)
     private PickupStatus status;        // 상태 (대기 중, 수락됨, 완료됨, 거절됨)
@@ -22,7 +24,7 @@ public class PickupUserSummaryDto {
     public static PickupUserSummaryDto fromEntity(Pickup pickup) {
         return PickupUserSummaryDto.builder()
                 .cafeName(pickup.getMember().getUsername())
-                .requestDate(pickup.getCreatedDate().toLocalDate())
+                .requestDate(pickup.getCreatedDate())
                 .pickupDate(pickup.getPickupDate())
                 //.beanName(pickup.getGround().getBean().getName())
                 .amount(pickup.getAmount())

--- a/src/main/java/com/gdg/coffee/domain/pickup/exception/PickupErrorCode.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/exception/PickupErrorCode.java
@@ -8,6 +8,7 @@ public enum PickupErrorCode implements ErrorResponse {
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PICKUP401", "요청에 대한 작업자가 아닙니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "PICKUP400", "유효하지 않은 입력값입니다."),
     ALREADY_COMPLETED(HttpStatus.CONFLICT, "PICKUP410", "이미 완료된 픽업 요청입니다."),
+    ALREADY_REJECTED(HttpStatus.CONFLICT, "PICKUP411", "이미 거절된 픽업 요청입니다."),
     CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "PICKUP412", "현재 상태에서 픽업 요청을 취소할 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PICKUP500", "서버 내부 오류가 발생했습니다.");
 


### PR DESCRIPTION
## 🍃 관련이슈
- Resolved: #48

## 🌱 변경사항
- 픽업 목록 조회 시 QueryDSL 프로젝션과 DTO 생성자 시그니처 불일치로 발생했던 ExpressionException을 해결 (DTO/Projection 수정)
- 커피 찌꺼기(CoffeeGround) 생성 시 `remainingAmount` 필드가 입력값대로 저장되지 않고 0으로 잘못 저장되던 버그를 수정
- 픽업 완료 처리 시, 해당 수거량(`amount`)만큼 연결된 커피 찌꺼기(`CoffeeGround`)의 `remainingAmount`를 감소시키고 잔여량에 따라 찌꺼기 상태(`COMPLETED`/`IN_PROGRESS`)를 업데이트하는 비즈니스 로직을 구현 (CoffeeGroundService로 로직 위임)
- 픽업 목록 조회 응답 DTO에 `pickupId`가 올바르게 포함되도록 수정
- 카페 사용자에 대한 수거 요청 목록 조회 시, `memberId`가 아닌 올바른 `cafeId`로 필터링하도록 로직을 수정 (Service 레이어에서 `memberId`로 `cafeId`를 찾아 쿼리에 전달)
- 픽업 상태 변경 로직에 해당 픽업이 요청자의 카페와 관련 있는지 확인하는 권한 검증 로직을 추가