### PR TITLE
[Feat] Cafe 위치 기반 검색 기능 및 환경 기여도 조회 API 구현

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/controller/CafeController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 @Tag(name = "Cafe", description = "카페 관련 API")
 @Slf4j
 @RestController
@@ -113,4 +115,19 @@ public class CafeController {
         return ApiResponse.success(CafeSuccessCode.CAFE_EXIST_CHECK_SUCCESS, hasCafe);
     }
 
+    @GetMapping("/near")
+    @Operation(summary = "반경 내 카페 목록 조회 (5km)", description = """
+        ## 현재 위치 반경 5km 이내의 카페 목록을 조회합니다.
+        - 누구나 접근 가능합니다.
+        - 요청 파라미터로 사용자의 현재 위치(위도, 경도)를 전달해야 합니다.
+        - 유효한 범위(-90~90, -180~180)
+        - 결과는 거리가 가까운 순서로 정렬되지 않을 수 있으며, 이 기능은 현재 페이징을 지원하지 않습니다.
+        """)
+    public ApiResponse<List<CafeResponseDto>> getNearbyCafes(
+            @RequestParam("latitude") double latitude,
+            @RequestParam("longitude") double longitude
+    ) {
+        List<CafeResponseDto> nearbyCafes = cafeService.findCafesNear(latitude, longitude);
+        return ApiResponse.success(CafeSuccessCode.CAFE_GET_NEARBY_LIST_SUCCESS, nearbyCafes);
+    }
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeSuccessCode.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/exception/CafeSuccessCode.java
@@ -8,8 +8,8 @@ public enum CafeSuccessCode implements SuccessResponse {
     CAFE_GET_SUCCESS      (HttpStatus.OK,      "CAFE_GET_SUCCESS",       "카페 정보를 성공적으로 조회했습니다."),
     CAFE_GET_LIST_SUCCESS (HttpStatus.OK,      "CAFE_GET_LIST_SUCCESS",  "카페 목록을 성공적으로 조회했습니다."),
     CAFE_UPDATE_SUCCESS   (HttpStatus.OK,      "CAFE_UPDATE_SUCCESS",    "카페 정보가 성공적으로 수정되었습니다."),
-    CAFE_EXIST_CHECK_SUCCESS(HttpStatus.OK, "CAFE_EXIST_CHECK_SUCCESS", "카페 존재 여부를 성공적으로 확인했습니다.");
-
+    CAFE_EXIST_CHECK_SUCCESS(HttpStatus.OK, "CAFE_EXIST_CHECK_SUCCESS", "카페 존재 여부를 성공적으로 확인했습니다."),
+    CAFE_GET_NEARBY_LIST_SUCCESS(HttpStatus.OK, "CAFE_GET_NEARBY_LIST_SUCCESS", "반경 내 카페 목록을 성공적으로 조회했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepository.java
@@ -5,7 +5,7 @@ import com.gdg.coffee.domain.cafe.domain.Cafe;
 
 import java.util.Optional;
 
-public interface CafeRepository extends JpaRepository<Cafe, Long> {
+public interface CafeRepository extends JpaRepository<Cafe, Long>, CafeRepositoryCustom {
     Optional<Cafe> findByMemberId(Long memberId);
     boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepositoryCustom.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gdg.coffee.domain.cafe.repository;
+
+import com.gdg.coffee.domain.cafe.domain.Cafe;
+import java.util.List;
+
+public interface CafeRepositoryCustom {
+     // 위도/경도 좌표 기준, 5km 내부에 존재하는 카페 목록 조회
+    List<Cafe> findCafesNear(double latitude, double longitude);
+}

--- a/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepositoryImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/repository/CafeRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.gdg.coffee.domain.cafe.repository;
+
+import com.gdg.coffee.domain.cafe.domain.Cafe;
+import com.gdg.coffee.domain.cafe.domain.QCafe;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CafeRepositoryImpl implements CafeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QCafe cafe = QCafe.cafe;
+
+    // 고정된 반경 5km 상수 정의
+    private static final double FIXED_RADIUS_KM = 5.0;
+
+    @Override
+    public List<Cafe> findCafesNear(double latitude, double longitude) {
+
+        // 데이터베이스 공간 함수 ST_Distance_Sphere를 사용하여 거리를 계산하는 표현식 (결과: 미터)
+        NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
+                "ST_Distance_Sphere(point({0}, {1}), point({2}, {3}))",
+                cafe.longitude, cafe.latitude, longitude, latitude);
+
+        // 킬로미터로 변환 (미터 / 1000)
+        NumberExpression<Double> distanceKm = distance.divide(1000.0);
+
+        return queryFactory
+                .selectFrom(cafe)
+                .where(distanceKm.loe(FIXED_RADIUS_KM)) // 계산된 거리가 고정된 반경(5km) 이하인 조건
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/CafeService.java
@@ -5,6 +5,8 @@ import com.gdg.coffee.domain.cafe.dto.CafeResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CafeService {
 
     /** 카페 신규 등록 */
@@ -23,4 +25,7 @@ public interface CafeService {
 
     /** 정보 수정 */
     CafeResponseDto updateCafe(Long memberId, CafeRequestDto requestDto);
+
+    /** 근처 카페 목록 조회 */
+    List<CafeResponseDto> findCafesNear(double latitude, double longitude);
 }

--- a/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/cafe/service/impl/CafeServiceImpl.java
@@ -22,6 +22,9 @@ import com.gdg.coffee.domain.cafe.service.CafeService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -104,5 +107,15 @@ public class CafeServiceImpl implements CafeService {
 
         cafe.update(requestDto);          // dto 필드가 null 이면 유지
         return CafeResponseDto.fromEntity(cafe);
+    }
+
+    @Override
+    public List<CafeResponseDto> findCafesNear(double latitude, double longitude){
+        // 반경 5km 내 Cafe 엔티티 목록을 조회
+        List<Cafe> cafes = cafeRepository.findCafesNear(latitude, longitude);
+
+        return cafes.stream()
+                .map(CafeResponseDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/ground/repository/CoffeeGroundRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/repository/CoffeeGroundRepository.java
@@ -1,10 +1,12 @@
 package com.gdg.coffee.domain.ground.repository;
 
 import com.gdg.coffee.domain.ground.domain.CoffeeGround;
+import com.gdg.coffee.domain.ground.domain.CoffeeGroundStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CoffeeGroundRepository extends JpaRepository<CoffeeGround, Long> {
     List<CoffeeGround> findAllByCafeId(Long cafeId);
+    List<CoffeeGround> findByCafeIdAndStatus(Long cafeId, CoffeeGroundStatus status);
 }

--- a/src/main/java/com/gdg/coffee/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/coffee/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.gdg.coffee.domain.member.controller;
 
+import com.gdg.coffee.domain.member.dto.EnvReportResponseDto;
 import com.gdg.coffee.domain.member.dto.MemberInfoResponseDto;
 import com.gdg.coffee.domain.member.exception.MemberSuccessCode;
 import com.gdg.coffee.domain.member.service.MemberService;
@@ -35,5 +36,19 @@ public class MemberController {
         MemberInfoResponseDto memberInfo = memberService.getMemberInfo(memberId);
         log.info("Member Info: {}", memberInfo);
         return ResponseEntity.ok(ApiResponse.success(MemberSuccessCode.INFO_SUCCESS, memberInfo));
+    }
+
+    @GetMapping("/me/report")
+    @Operation(summary = "[구현완료] 회원 환경 기여도 조회", description = """
+        ## 로그인한 사용자의 총 환경 기여도 정보를 조회합니다.
+        - JWT 토큰을 통해 인증된 사용자 (USER 또는 CAFE)만 접근 가능합니다.
+        - USER: 완료된 Pickup의 총량을 기준으로 환경 기여도를 계산합니다.
+        - CAFE: 완료된 CoffeeGround의 총량을 기준으로 환경 기여도를 계산합니다.
+        - 응답에는 총 기여량, 계산된 CO2 감소량, 처리된 수거 횟수가 포함됩니다.
+        """)
+    public ResponseEntity<ApiResponse<EnvReportResponseDto>> getEnvironmentalReport() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        EnvReportResponseDto report = memberService.getEnvironmentalReport(memberId);
+        return ResponseEntity.ok(ApiResponse.success(MemberSuccessCode.REPORT_SUCCESS, report)); // Success Code는 프로젝트에 맞게 수정
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/member/dto/EnvReportResponseDto.java
+++ b/src/main/java/com/gdg/coffee/domain/member/dto/EnvReportResponseDto.java
@@ -1,0 +1,13 @@
+package com.gdg.coffee.domain.member.dto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EnvReportResponseDto {
+    private float totalCollected;
+    private String carbonSaved;
+    private int reportCount;
+}

--- a/src/main/java/com/gdg/coffee/domain/member/exception/MemberSuccessCode.java
+++ b/src/main/java/com/gdg/coffee/domain/member/exception/MemberSuccessCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum MemberSuccessCode implements SuccessResponse {
 
-    INFO_SUCCESS(HttpStatus.OK,"MEMBER_INFO_SUCCESS","회원정보 조회에 성공했습니다.");
+    INFO_SUCCESS(HttpStatus.OK,"MEMBER_INFO_SUCCESS","회원정보 조회에 성공했습니다."),
+    REPORT_SUCCESS(HttpStatus.OK, "MEMBER_REPORT_SUCCESS", "환경 기여도 조회가 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gdg/coffee/domain/member/service/MemberService.java
+++ b/src/main/java/com/gdg/coffee/domain/member/service/MemberService.java
@@ -1,17 +1,37 @@
 package com.gdg.coffee.domain.member.service;
 
+import java.util.List;
+import com.gdg.coffee.domain.cafe.domain.Cafe;
+import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
+import com.gdg.coffee.domain.ground.domain.CoffeeGround;
+import com.gdg.coffee.domain.ground.domain.CoffeeGroundStatus;
+import com.gdg.coffee.domain.pickup.domain.Pickup;
+import com.gdg.coffee.domain.cafe.repository.CafeRepository;
+import com.gdg.coffee.domain.ground.repository.CoffeeGroundRepository;
+import com.gdg.coffee.domain.member.domain.MemberRole;
+import com.gdg.coffee.domain.member.dto.EnvReportResponseDto;
 import com.gdg.coffee.domain.member.domain.Member;
 import com.gdg.coffee.domain.member.dto.MemberInfoResponseDto;
 import com.gdg.coffee.domain.member.exception.MemberErrorCode;
 import com.gdg.coffee.domain.member.exception.MemberException;
 import com.gdg.coffee.domain.member.repository.MemberRepository;
+import com.gdg.coffee.domain.pickup.dto.PickupStatus;
+import com.gdg.coffee.domain.pickup.repository.PickupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional (readOnly = true)
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final PickupRepository pickupRepository;
+    private final CoffeeGroundRepository coffeeGroundRepository;
+    private final CafeRepository cafeRepository;
+
+    // CO2 변환 계수: 커피 찌꺼기 1L당 약 0.6kg CO2 절감 효과
+    private static final float CO2_KG_PER_LITER_GROUND = 0.6f;
 
     public MemberInfoResponseDto getMemberInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -24,5 +44,50 @@ public class MemberService {
                 member.getRole(),
                 member.getProfileImage()
         );
+    }
+
+    /**
+     * 현재 인증된 사용자의 환경 기여도 리포트를 조회합니다.
+     * 사용자의 역할(USER/CAFE)에 따라 다른 기준으로 기여도를 계산합니다.
+     * @param memberId 현재 인증된 회원의 ID
+     * @return 환경 기여도 정보를 담은 EnvReportResponseDto
+     */
+    public EnvReportResponseDto getEnvironmentalReport(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        float totalAmount = 0; // 총량
+        int reportCount = 0; // 관련 항목 개수
+
+        // User는 Pickup을 통해 수거한 커피 찌꺼기 양을 기준으로 환경 기여도 계산
+        if (member.getRole() == MemberRole.USER) {
+            // Completed 상태의 Pickup을 조회
+            List<Pickup> completedPickups = pickupRepository.findByMemberIdAndStatus(memberId, PickupStatus.COMPLETED);
+
+            // 총량과 수거 완료 횟수
+            totalAmount = (float) completedPickups.stream().mapToDouble(Pickup::getAmount).sum();
+            reportCount = completedPickups.size();
+        }
+        // Cafe는 CoffeeGround를 통해 배출한 커피 찌꺼기 양을 기준으로 환경 기여도 계산
+        else if (member.getRole() == MemberRole.CAFE) {
+            Cafe cafe = cafeRepository.findByMemberId(memberId)
+                    .orElseThrow(() -> new MemberException(CafeErrorCode.CAFE_NOT_FOUND_BY_MEMBER));
+            Long cafeId = cafe.getId();
+
+            // Completed 상태의 CoffeeGround를 조회
+            List<CoffeeGround> completedGrounds = coffeeGroundRepository.findByCafeIdAndStatus(cafeId, CoffeeGroundStatus.COMPLETED);
+
+            // 총량과 배출 완료 횟수
+            totalAmount = (float) completedGrounds.stream().mapToDouble(CoffeeGround::getTotalAmount).sum();
+            reportCount = completedGrounds.size();
+        }
+
+        float co2ImpactKg = totalAmount * CO2_KG_PER_LITER_GROUND;
+
+        return EnvReportResponseDto.builder()
+                .totalCollected(totalAmount)
+                .carbonSaved(String.format("%.1f", co2ImpactKg)) // CO2 감소량 (소수점 1자리까지)
+                .reportCount(reportCount)
+                .build();
     }
 }

--- a/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepository.java
@@ -16,5 +16,6 @@ public interface PickupRepository extends JpaRepository<Pickup, Long>, PickupRep
     List<Pickup> findByGroundCafeId(Long cafeId);
     // 사용자 기준 전체 수거 요청 조회
     List<Pickup> findByMemberId(Long memberId);
-
+    // 사용자 기준 수거 요청 상태별 조회
+    List<Pickup> findByMemberIdAndStatus(Long memberId, PickupStatus status);
 }


### PR DESCRIPTION
## 🍃 관련이슈
- Resolved: #49

## 🌱 변경사항
- 카페 위치 기반 검색 기능 추가
    - 사용자의 현재 위치(위도, 경도)를 기반으로 반경 5km 이내의 카페 목록을 조회하는 새로운 API 엔드포인트 (`GET /api/cafes/near`)를 구현
    - 데이터베이스의 공간 함수(MySQL: `ST_Distance_Sphere`)와 QueryDSL을 활용
    - 관련 Success Code를 추가

- 환경 리포트 기능 추가
    - 로그인한 사용자의 환경 기여도 정보를 조회하는 새로운 API 엔드포인트 (`GET /api/users/me/report`)를 회원(member) 도메인 내에 구현
    - Service 계층에서 사용자 역할(USER/CAFE)에 따라 완료된 항목(픽업/그라운드)을 기준으로 환경 기여도(총량, CO2 영향)를 계산하는 비즈니스 로직을 구현
    - 환경 리포트 응답 DTO(`EnvReportResponseDto`)를 정의
    - 기여도 계산에 필요한 Repository 조회 메소드들을 추가
    - 관련 Success Code를 추가