### PR TITLE
[Fix] 검증 및 권한 확인 오류 수정

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
@@ -14,6 +14,7 @@ import com.gdg.coffee.domain.ground.exception.CoffeeGroundErrorCode;
 import com.gdg.coffee.domain.ground.exception.CoffeeGroundException;
 import com.gdg.coffee.domain.ground.repository.CoffeeGroundRepository;
 import com.gdg.coffee.domain.ground.service.CoffeeGroundService;
+import com.gdg.coffee.domain.member.domain.Member;
 import com.gdg.coffee.domain.member.exception.MemberErrorCode;
 import com.gdg.coffee.domain.member.exception.MemberException;
 import com.gdg.coffee.domain.member.repository.MemberRepository;
@@ -82,7 +83,7 @@ public class CoffeeGroundServiceImpl implements CoffeeGroundService {
         CoffeeGround ground = groundRepo.findById(groundId)
                 .orElseThrow(() -> new CoffeeGroundException(CoffeeGroundErrorCode.GROUND_NOT_FOUND));
 
-        Cafe cafe = cafeRepo.findById(memberId)
+        Cafe cafe = cafeRepo.findByMemberId(memberId)
                 .orElseThrow(() -> new CoffeeGroundException(CoffeeGroundErrorCode.GROUND_FORBIDDEN));
 
         if(!ground.getCafe().getId().equals(cafe.getId())) {

--- a/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
@@ -14,7 +14,6 @@ import com.gdg.coffee.domain.ground.exception.CoffeeGroundErrorCode;
 import com.gdg.coffee.domain.ground.exception.CoffeeGroundException;
 import com.gdg.coffee.domain.ground.repository.CoffeeGroundRepository;
 import com.gdg.coffee.domain.ground.service.CoffeeGroundService;
-import com.gdg.coffee.domain.member.domain.Member;
 import com.gdg.coffee.domain.member.exception.MemberErrorCode;
 import com.gdg.coffee.domain.member.exception.MemberException;
 import com.gdg.coffee.domain.member.repository.MemberRepository;

--- a/src/main/java/com/gdg/coffee/domain/pickup/service/PickupService.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/service/PickupService.java
@@ -46,7 +46,7 @@ public class PickupService {
             throw  new PickupException(PickupErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        if (requestDto.getAmount() <= 0 && ground.getRemainingAmount() < requestDto.getAmount()) {
+        if (requestDto.getAmount() <= 0 || ground.getRemainingAmount() < requestDto.getAmount()) {
             throw new PickupException(PickupErrorCode.INVALID_INPUT);
         }
 


### PR DESCRIPTION
1. 수거 요청 시 유효하지 않은 수거량 입력 방지 로직 수정
    - 수거 요청을 생성(POST)할 때, 요청된 수거량(`amount`)이 0보다 작거나 같거나 혹은 해당 커피 찌꺼기의 현재 잔여량(`remainingAmount`)보다 많은 경우, 시스템에서 오류를 발생시켜 유효하지 않은 요청을 거부해야 합니다. 하지만 검증 조건의 논리 연산자 오류로 인해 이 로직이 올바르게 동작하지 않았습니다. 논리 연산자(`&&` -> `||`)를 수정하여 유효하지 않은 요청량을 올바르게 감지하고 처리하도록 수정했습니다.

2. 커피 찌꺼기 삭제 시, 삭제 권한 확인을 위해 카페 소유자를 올바르게 찾도록 수정
    - 커피 찌꺼기를 삭제하는 요청이 들어왔을 때, 해당 찌꺼기를 등록한 카페의 소유자(현재 로그인한 회원)인지 확인하는 로직이 있었습니다. 이때, 카페를 찾는 과정에서 `cafeRepository.findById(memberId)` 메소드를 사용하는 잘못된 방식이었습니다. 회원 ID와 연관 관계를 통해 연결된 카페를 올바르게 찾기 위해 `cafeRepository.findByMemberId(memberId)` 메소드를 사용하도록 수정했습니다.