### PR TITLE
Feat/cafe

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/gdg/coffee/domain/auth/controller/AuthController.java
@@ -19,7 +19,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.util.Map;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -85,8 +86,15 @@ public class AuthController {
         """
     )
     @GetMapping("/google/callback")
-    public ResponseEntity<ApiResponse<MemberLoginResponseDto>> googleCallback(@RequestParam("code") String code) {
-        MemberLoginResponseDto response = googleOAuthService.loginGoogle(code);
-        return ResponseEntity.ok(ApiResponse.success(AuthSuccessCode.LOGIN_SUCCESS, response));
+    public void googleCallback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
+        MemberLoginResponseDto dto = googleOAuthService.loginGoogle(code);
+
+        // 프론트엔드 리다이렉트 URL (개발 시에는 localhost로)
+        String redirectUrl = "http://localhost:8080/oauth/google/callback" +
+                "?accessToken=" + dto.getAccessToken() +
+                "&refreshToken=" + dto.getRefreshToken() +
+                "&username=" + URLEncoder.encode(dto.getUsername(), StandardCharsets.UTF_8);
+
+        response.sendRedirect(redirectUrl);
     }
 }


### PR DESCRIPTION
## 📌 변경 내용
Google OAuth 로그인 완료 후, 기존에는 서버가 accessToken, refreshToken을 포함한 JSON을 응답으로 반환하고 클라이언트가 이 응답을 직접 처리하는 방식이었습니다.

- 로그인 완료 후 클라이언트 도메인 (/oauth/callback)으로 리다이렉트
- accessToken, refreshToken, username을 쿼리 파라미터로 함께 전달

## ✅ 변경 이유

- JSON 응답이 브라우저에 직접 노출되는 문제 해결
- 리다이렉트 기반 흐름으로 사용자 경험 개선
- 클라이언트 측 라우팅 및 토큰 저장 책임을 명확히 분리
