### PR TITLE
Feat/pickup [Fix]: 500 error on pickup list APIs due to invalid fetchJoin with DTO projection

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
@@ -118,11 +118,11 @@ public class PickupController {
     @PutMapping("/pickups/{pickupId}/status")
     @Operation(summary = "수거 요청 상태 변경", description = """
         ## 수거 요청의 상태를 변경합니다.
-            수거 요청 상태 종류: 
-            PENDING,
-            ACCEPTED,
-            COMPLETED,
-            REJECTED
+        수거 요청 상태 종류: 
+        PENDING,
+        ACCEPTED,
+        COMPLETED,
+        REJECTED
         """)
     public ApiResponse<Void> updatePickupStatus(
             @PathVariable Long pickupId,

--- a/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/controller/PickupController.java
@@ -118,7 +118,11 @@ public class PickupController {
     @PutMapping("/pickups/{pickupId}/status")
     @Operation(summary = "수거 요청 상태 변경", description = """
         ## 수거 요청의 상태를 변경합니다.
-        * 예: WAITING → COMPLETED
+            수거 요청 상태 종류: 
+            PENDING,
+            ACCEPTED,
+            COMPLETED,
+            REJECTED
         """)
     public ApiResponse<Void> updatePickupStatus(
             @PathVariable Long pickupId,

--- a/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/dto/PickupRequestDto.java
@@ -3,6 +3,8 @@ package com.gdg.coffee.domain.pickup.dto;
 import com.gdg.coffee.domain.ground.domain.CoffeeGround;
 import com.gdg.coffee.domain.member.domain.Member;
 import com.gdg.coffee.domain.pickup.domain.Pickup;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,8 +13,14 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 public class PickupRequestDto {
+
+    @NotNull(message = "수거 요청량은 필수입니다.")
+    @Positive(message = "수거 요청량은 0보다 커야 합니다.")
     private float amount;               // 수거 요청할 양
+
     private String message;             // 수거 요청 메시지 (선택)
+
+    @NotNull(message = "희망 수거일은 필수입니다.")
     private LocalDate pickupDate;       // 희망 수거일
 
     public static Pickup toEntity(PickupRequestDto requestDto, Member member, CoffeeGround ground) {

--- a/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepositoryImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepositoryImpl.java
@@ -77,9 +77,9 @@ public class PickupRepositoryImpl implements PickupRepositoryCustom{
                         p.status
                 ))
                 .from(p)
-                .join(p.ground, g).fetchJoin()
-                .join(g.cafe, c).fetchJoin()
-                .join(g.bean, b).fetchJoin()
+                .join(p.ground, g)
+                .join(g.cafe, c)
+                .join(g.bean, b)
                 .where(builder)
                 .fetch();
     }

--- a/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepositoryImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/pickup/repository/PickupRepositoryImpl.java
@@ -49,9 +49,9 @@ public class PickupRepositoryImpl implements PickupRepositoryCustom{
                         p.status
                 ))
                 .from(p)
-                .join(p.member, m).fetchJoin()   // Lazy 로딩 방지
-                .join(p.ground, g).fetchJoin()
-                .join(g.bean, b).fetchJoin()
+                .join(p.member, m) // fetchJoin 제거
+                .join(p.ground, g)
+                .join(g.bean, b)
                 .where(builder)
                 .fetch();
     }


### PR DESCRIPTION
# 🧾 변경 사항 요약
## 에러 발생 원인

**/api/mypage/pickups와 /api/cafe/pickups API에서 500 Internal Server Error 발생**

원인은 Hibernate 6에서 DTO Projection과 fetchJoin을 동시에 사용할 수 없기 때문

Projections.constructor()를 사용하는 QueryDSL DTO 매핑과 fetchJoin()을 같이 사용하면,
Hibernate가 select 절에 없는 엔티티에 fetchJoin이 걸려 있다는 이유로 SemanticException 발생

## 수정 내용

```
pickupRepository.findUserPickupListByStatusDsl(...)
pickupRepository.findCafePickupListByStatusDsl(...)
```

위 두 메서드에서 모든 fetchJoin을 일반 join으로 변경

Lazy 로딩이 필요 없는 필드들만 select 절에 명시했기 때문에 fetchJoin 제거해도 데이터 누락 없음
