### PR TITLE
카페별 찌꺼기 목록 조회 api 추가 및 버그 수정

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
@@ -73,7 +73,7 @@ public class CoffeeGroundController {
         return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_LIST_SUCCESS, coffeeGrounds); // 기존 SuccessCode 사용
     }
 
-    /* 4. 삭제 */
+    /* 5. 삭제 */
     @DeleteMapping("/coffee_grounds/{groundId}")
     @Operation(summary = "[구현완료] 커피 찌꺼기 삭제", description = """
         ## 커피 찌꺼기 ID를 통해 삭제합니다.

--- a/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
@@ -48,7 +48,7 @@ public class CoffeeGroundController {
         return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_GET_SUCCESS, response);
     }
 
-    /* 3. 목록 (카페별) */
+    /* 3. 목록 (내 카페의 찌꺼기 목록) */
     @GetMapping("/cafe/coffee_grounds")
     @Operation(summary = "[구현완료] 내 카페 커피 찌꺼기 목록 조회", description = """
         ## 로그인한 카페 사용자의 소속 카페에서 등록한 찌꺼기 목록을 조회합니다.
@@ -58,6 +58,19 @@ public class CoffeeGroundController {
         Long memberId = SecurityUtil.getCurrentMemberId();
         List<CoffeeGroundResponseDto> response = groundService.getGroundsOfCafe(memberId);
         return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_LIST_SUCCESS, response);
+    }
+
+    /* 4. 목록 (특정 카페의 찌꺼기 목록, 전체 공개) */
+    @GetMapping("/coffee_grounds/cafe/{cafeId}")
+    @Operation(summary = "카페별 찌꺼기 목록 조회 (전체 공개)", description = """
+        ## 특정 카페가 등록한 모든 커피 찌꺼기 목록을 상세 정보와 함께 조회합니다.
+        - 카페 ID를 경로 변수로 전달해야 합니다.
+        - 누구나 접근 가능하며, 카페/사용자 모두 확인 가능합니다.
+        - 응답은 해당 카페가 등록한 찌꺼기의 상세 정보 목록입니다.
+        """)
+    public ApiResponse<List<CoffeeGroundResponseDto>> getGroundsByCafeId(@PathVariable("cafeId") Long cafeId) {
+        List<CoffeeGroundResponseDto> coffeeGrounds = groundService.getGroundsByCafeId(cafeId);
+        return ApiResponse.success(CoffeeGroundSuccessCode.GROUND_LIST_SUCCESS, coffeeGrounds); // 기존 SuccessCode 사용
     }
 
     /* 4. 삭제 */

--- a/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/controller/CoffeeGroundController.java
@@ -62,7 +62,7 @@ public class CoffeeGroundController {
 
     /* 4. 목록 (특정 카페의 찌꺼기 목록, 전체 공개) */
     @GetMapping("/coffee_grounds/cafe/{cafeId}")
-    @Operation(summary = "카페별 찌꺼기 목록 조회 (전체 공개)", description = """
+    @Operation(summary = "카페별 찌꺼기 목록 조회", description = """
         ## 특정 카페가 등록한 모든 커피 찌꺼기 목록을 상세 정보와 함께 조회합니다.
         - 카페 ID를 경로 변수로 전달해야 합니다.
         - 누구나 접근 가능하며, 카페/사용자 모두 확인 가능합니다.

--- a/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/CoffeeGroundService.java
@@ -13,6 +13,9 @@ public interface CoffeeGroundService {
     /** 카페별 원두 목록 조회 */
     List<CoffeeGroundResponseDto> getGroundsOfCafe(Long memberId);
 
+    /** 카페별 원두 목록 조회 (카페 ID로) */
+    List<CoffeeGroundResponseDto> getGroundsByCafeId(Long cafeId);
+
     /** 원두 삭제 */
     void deleteGround(Long groundId, Long memberId);
 

--- a/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
+++ b/src/main/java/com/gdg/coffee/domain/ground/service/impl/CoffeeGroundServiceImpl.java
@@ -5,6 +5,7 @@ import com.gdg.coffee.domain.bean.exception.BeanErrorCode;
 import com.gdg.coffee.domain.bean.repository.BeanRepository;
 import com.gdg.coffee.domain.cafe.domain.Cafe;
 import com.gdg.coffee.domain.cafe.exception.CafeErrorCode;
+import com.gdg.coffee.domain.cafe.exception.CafeException;
 import com.gdg.coffee.domain.cafe.repository.CafeRepository;
 import com.gdg.coffee.domain.ground.domain.CoffeeGround;
 import com.gdg.coffee.domain.ground.domain.CoffeeGroundStatus;
@@ -74,6 +75,15 @@ public class CoffeeGroundServiceImpl implements CoffeeGroundService {
 
         return groundRepo.findAllByCafeId(cafe.getId()).stream()
                 .map(CoffeeGroundResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CoffeeGroundResponseDto> getGroundsByCafeId(Long cafeId){
+        cafeRepo.findById(cafeId).orElseThrow(() -> new CafeException(CafeErrorCode.CAFE_NOT_FOUND));
+
+        return groundRepo.findAllByCafeId(cafeId).stream()
+                .map(CoffeeGroundResponseDto::fromEntity) // 엔티티를 DTO로 매핑
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/SecurityConfig.java
@@ -46,8 +46,8 @@ public class SecurityConfig {
                                 .requestMatchers("/api/member/info").hasRole("USER")
                                 .requestMatchers(HttpMethod.GET, "/api/cafes/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/beans/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/grounds/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/grounds").hasRole("CAFE")
+                                .requestMatchers(HttpMethod.GET, "/api/coffee_grounds/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/coffee_grounds").hasRole("CAFE")
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 🌱 변경사항
### 새로운 API 구현
- 특정 카페 찌꺼기 목록 조회 API (`GET /api/coffee_grounds/cafe/{cafeId}`) 추가:
    - 특정 카페 ID를 경로 변수로 받아, 해당 카페가 등록한 모든 커피 찌꺼기 목록(상세 정보 포함)을 누구나 조회할 수 있는 공개 API를 구현했습니다.
    - 이를 위해 CoffeeGround 도메인 내 Service 및 Repository 로직을 추가했습니다.

### 버그 수정 및 개선
- Spring Security API 경로 오타 수정:
    - `SecurityConfig` 파일에서 커피 찌꺼기 관련 API 경로를 지정하는 부분의 오타(`/api/grounds/**`)를 실제 사용되는 경로(`/api/coffee_grounds/**`)로 수정하여, 해당 API에 대한 보안 규칙이 올바르게 적용되도록 했습니다.
