### PR TITLE
[Add] Gemini API 연동을 통한 업사이클링 솔루션 생성 기능 구현

### DIFF
--- a/src/main/java/com/gdg/coffee/domain/solution/controller/SolutionController.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/controller/SolutionController.java
@@ -1,0 +1,39 @@
+package com.gdg.coffee.domain.solution.controller;
+
+import com.gdg.coffee.domain.solution.dto.request.SolutionRequestDto;
+import com.gdg.coffee.domain.solution.dto.response.SolutionResponseDto;
+import com.gdg.coffee.domain.solution.exception.SolutionSuccessCode;
+import com.gdg.coffee.domain.solution.service.SolutionService;
+import com.gdg.coffee.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/solutions")
+public class SolutionController {
+
+    private final SolutionService solutionService;
+
+    @PostMapping("/generate")
+    public ResponseEntity<ApiResponse<List<SolutionResponseDto>>> generateSolutions(
+            @RequestBody SolutionRequestDto request
+    ) {
+        List<SolutionResponseDto> result = solutionService.generateSolutions(request);
+        return new ResponseEntity<>(ApiResponse.success(SolutionSuccessCode.GENERATED, result), HttpStatus.CREATED);
+    }
+
+    /**
+     * 특정 솔루션 상세 조회
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<SolutionResponseDto>> getSolutionById(@PathVariable Long id) {
+        SolutionResponseDto solution = solutionService.getSolutionById(id);
+        return new ResponseEntity<>(ApiResponse.success(SolutionSuccessCode.GET_DETAILS, solution), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/domain/Solution.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/domain/Solution.java
@@ -1,0 +1,45 @@
+package com.gdg.coffee.domain.solution.domain;
+
+import com.gdg.coffee.domain.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Solution extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @ElementCollection
+    private List<String> tags;
+
+    private String difficulty;
+
+    private String duration;
+
+    @ElementCollection
+    private List<String> materials;
+
+    @ElementCollection
+    private List<String> steps;
+
+    private String purpose;
+
+    private String beanType;
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/dto/request/GeminiRequest.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/dto/request/GeminiRequest.java
@@ -1,0 +1,32 @@
+package com.gdg.coffee.domain.solution.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiRequest {
+    private List<Content> contents;
+
+    public static GeminiRequest of(String prompt) {
+        Part part = new Part(prompt);
+        Content content = new Content(List.of(part));
+        return new GeminiRequest(List.of(content));
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Part {
+        private String text;
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/dto/request/SolutionRequestDto.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/dto/request/SolutionRequestDto.java
@@ -1,0 +1,9 @@
+package com.gdg.coffee.domain.solution.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class SolutionRequestDto {
+    private String purpose;   // 활용 목적
+    private String beanType; // 원두 종류
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/dto/response/GeminiResponse.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/dto/response/GeminiResponse.java
@@ -1,0 +1,25 @@
+package com.gdg.coffee.domain.solution.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class GeminiResponse {
+    private List<Candidate> candidates;
+
+    @Data
+    public static class Candidate {
+        private Content content;
+    }
+
+    @Data
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Data
+    public static class Part {
+        private String text;
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/dto/response/SolutionResponseDto.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/dto/response/SolutionResponseDto.java
@@ -1,0 +1,33 @@
+package com.gdg.coffee.domain.solution.dto.response;
+
+import com.gdg.coffee.domain.solution.domain.Solution;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SolutionResponseDto {
+    private Long id;
+    private String title;               // 예: "커피 방향제 만들기"
+    private String description;         // 간단 소개
+    private List<String> tags;          // 예: ["방향제", "탈취", "인테리어"]
+    private String difficulty;          // 예: "쉬움"
+    private String duration;            // 예: "15분"
+    private List<String> materials;     // 예: ["밀린 커피 찌꺼기 1컵", "베이킹 소다 1/2컵", ...]
+    private List<String> steps;         // 예: ["커피 찌꺼기를 완전히 말려...", "베이킹소다와 섞는다", ...]
+
+    public static SolutionResponseDto fromEntity(Solution solution){
+        return SolutionResponseDto.builder()
+                .id(solution.getId())
+                .title(solution.getTitle())
+                .description(solution.getDescription())
+                .tags(solution.getTags())
+                .difficulty(solution.getDifficulty())
+                .duration(solution.getDuration())
+                .materials(solution.getMaterials())
+                .steps(solution.getSteps())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionErrorCode.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionErrorCode.java
@@ -1,0 +1,39 @@
+package com.gdg.coffee.domain.solution.exception;
+
+import com.gdg.coffee.global.common.type.ErrorResponse;
+import org.springframework.http.HttpStatus;
+
+public enum SolutionErrorCode implements ErrorResponse {
+    PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GEMINI500", "Gemini 응답 파싱에 실패했습니다."),
+    REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "GEMINI502", "Gemini API 요청에 실패했습니다."),
+    EMPTY_RESPONSE(HttpStatus.NO_CONTENT, "GEMINI204", "Gemini 응답이 비어 있습니다."),
+    SOLUTION_NOT_FOUND(HttpStatus.NOT_FOUND, "GEMINI404", "존재하지 않는 솔루션입니다"),
+    INVALID_PROMPT(HttpStatus.BAD_REQUEST, "GEMINI400", "유효하지 않은 프롬프트 형식입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GEMINI501", "Gemini 처리 중 서버 오류가 발생했습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    SolutionErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionException.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionException.java
@@ -1,0 +1,11 @@
+package com.gdg.coffee.domain.solution.exception;
+
+import com.fasterxml.jackson.databind.ser.Serializers;
+import com.gdg.coffee.global.common.exception.BaseException;
+import com.gdg.coffee.global.common.type.ErrorResponse;
+
+public class SolutionException extends BaseException {
+    public SolutionException(ErrorResponse errorResponse) {
+        super(errorResponse);
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionSuccessCode.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/exception/SolutionSuccessCode.java
@@ -1,0 +1,31 @@
+package com.gdg.coffee.domain.solution.exception;
+
+import com.gdg.coffee.global.common.type.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SolutionSuccessCode implements SuccessResponse {
+    GENERATED(HttpStatus.OK, "SOLUTION200", "업사이클링 솔루션이 성공적으로 생성되었습니다."),
+    GET_DETAILS(HttpStatus.OK, "SOLUTION201", "업사이클링 솔루션 조회를 성공했습니다."),
+    CUSTOM_RECOMMENDATION(HttpStatus.OK, "SOLUTION202", "사용자 조건에 따른 맞춤형 솔루션을 성공적으로 생성하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/repository/SolutionRepository.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/repository/SolutionRepository.java
@@ -1,0 +1,9 @@
+package com.gdg.coffee.domain.solution.repository;
+
+import com.gdg.coffee.domain.solution.domain.Solution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SolutionRepository extends JpaRepository<Solution, Long> {
+}

--- a/src/main/java/com/gdg/coffee/domain/solution/service/SolutionService.java
+++ b/src/main/java/com/gdg/coffee/domain/solution/service/SolutionService.java
@@ -1,0 +1,138 @@
+package com.gdg.coffee.domain.solution.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gdg.coffee.domain.solution.domain.Solution;
+import com.gdg.coffee.domain.solution.dto.request.GeminiRequest;
+import com.gdg.coffee.domain.solution.dto.request.SolutionRequestDto;
+import com.gdg.coffee.domain.solution.dto.response.GeminiResponse;
+import com.gdg.coffee.domain.solution.dto.response.SolutionResponseDto;
+import com.gdg.coffee.domain.solution.exception.SolutionErrorCode;
+import com.gdg.coffee.domain.solution.exception.SolutionException;
+import com.gdg.coffee.domain.solution.repository.SolutionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SolutionService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final SolutionRepository solutionRepository;
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    private static final String GEMINI_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=";
+
+    public List<SolutionResponseDto> generateSolutions(SolutionRequestDto requestDto) {
+        // 1. 기존 데이터 삭제
+        solutionRepository.deleteAll();
+
+        // 2. Gemini 프롬프트 생성
+        String prompt = buildPrompt(requestDto);
+        GeminiRequest geminiRequest = GeminiRequest.of(prompt);
+
+        // 3. Gemini API 호출
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<GeminiRequest> entity = new HttpEntity<>(geminiRequest, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GEMINI_URL + apiKey,
+                HttpMethod.POST,
+                entity,
+                String.class
+        );
+
+        try {
+            // 4. Gemini 응답에서 리스트 형태 JSON 텍스트 추출
+            GeminiResponse geminiResponse = objectMapper.readValue(response.getBody(), GeminiResponse.class);
+            String raw = extractResponseText(geminiResponse);
+
+            // 5. JSON → List<SolutionResponseDto>
+            List<SolutionResponseDto> solutions = objectMapper.readValue(
+                    raw,
+                    new TypeReference<List<SolutionResponseDto>>() {}
+            );
+
+            // 6. DB 저장
+            List<Solution> savedSolutions = solutions.stream()
+                    .map(dto -> Solution.builder()
+                            .title(dto.getTitle())
+                            .description(dto.getDescription())
+                            .tags(dto.getTags())
+                            .difficulty(dto.getDifficulty())
+                            .duration(dto.getDuration())
+                            .materials(dto.getMaterials())
+                            .steps(dto.getSteps())
+                            .purpose(requestDto.getPurpose())
+                            .beanType(requestDto.getBeanType())
+                            .build())
+                    .map(solutionRepository::save)
+                    .toList();
+
+            return savedSolutions.stream()
+                    .map(SolutionResponseDto::fromEntity)
+                    .toList();
+
+        } catch (Exception e) {
+            throw new SolutionException(SolutionErrorCode.REQUEST_FAILED);
+        }
+    }
+
+    public SolutionResponseDto getSolutionById(Long id) {
+        Solution solution = solutionRepository.findById(id)
+                .orElseThrow(() -> new SolutionException(SolutionErrorCode.SOLUTION_NOT_FOUND));
+        return SolutionResponseDto.fromEntity(solution);
+    }
+
+
+    private String buildPrompt(SolutionRequestDto request) {
+        String purpose = request.getPurpose() == null ? "다양한 용도" : request.getPurpose();
+        String beanType = request.getBeanType() == null ? "모든 원두" : request.getBeanType();
+        return String.format(
+                "커피 찌꺼기를 활용한 업사이클링 솔루션을 JSON 리스트 형식으로 3개 추천해줘. " +
+                        "조건은 활용 목적: %s, 원두 종류: %s야.\n" +
+                        "응답 형식은 다음과 같아:\n" +
+                        "[\n" +
+                        "  {\n" +
+                        "    \"title\": \"...\",\n" +
+                        "    \"description\": \"...\",\n" +
+                        "    \"tags\": [\"...\"],\n" +
+                        "    \"difficulty\": \"쉬움/보통/어려움\",\n" +
+                        "    \"duration\": \"...\",\n" +
+                        "    \"materials\": [\"...\"],\n" +
+                        "    \"steps\": [\"...\"]\n" +
+                        "  }\n" +
+                        "]", purpose, beanType
+        );
+    }
+
+    private String extractResponseText(GeminiResponse response) {
+        if (response == null || response.getCandidates() == null || response.getCandidates().isEmpty()) {
+            throw new SolutionException(SolutionErrorCode.EMPTY_RESPONSE);
+        }
+
+        String raw = response.getCandidates().get(0).getContent().getParts().get(0).getText();
+
+        // markdown ```json 제거
+        if (raw.startsWith("```json")) {
+            raw = raw.replaceFirst("(?s)^```json\\s*", "");  // ```json + 줄바꿈 제거
+            raw = raw.replaceFirst("(?s)```\\s*$", "");       // 맨 마지막 ```
+        }
+
+        return raw.trim(); // 불필요한 공백 제거
+    }
+}

--- a/src/main/java/com/gdg/coffee/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/gdg/coffee/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.gdg.coffee.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
Closes #56 

## 주요 변경 사항
- Gemini API와 연동하여 커피 찌꺼기 업사이클링 솔루션 3개 자동 생성 기능 구현
- POST /api/solutions/generate: 목적/원두 선택값 기반으로 Gemini 프롬프트 생성 및 결과 DB 저장
- GET /api/solutions/{id}: 생성된 솔루션 중 하나를 ID로 상세 조회
- 요청 시마다 이전 솔루션은 삭제되고 새롭게 3개만 유지되도록 구성

## 기획 의도
- 사용자가 업사이클링 페이지에 진입할 때마다 새로운 제안을 받을 수 있도록 설계
- 솔루션 ID를 통해 상세 정보 확인 가능하며, 이전 솔루션은 접근 불가

## 참고사항
1. 페이지 진입 시 POST /api/solutions/generate 호출
2. 사용자가 페이지에 처음 접근하거나 목적/원두 선택 시 API 호출
3. 서버는 매번 새로운 3개의 솔루션을 생성해서 DB에 저장하고 그 결과를 리스트로 응답
4. 응답으로 받은 data 배열을 카드 형식으로 리스트로 보여주기
4. 상세 페이지 이동 시 GET /api/solutions/{id} 호출 (여기서 id는 앞의 POST의 응답으로 받음)

주의: 새로 생성 요청을 보내면 기존 솔루션은 DB에서 삭제됨